### PR TITLE
freebsd: fix compiling error with gcc 6.3.1

### DIFF
--- a/freebsd/netinet/cc/cc_cubic.c
+++ b/freebsd/netinet/cc/cc_cubic.c
@@ -261,9 +261,10 @@ cubic_cong_signal(struct cc_var *ccv, uint32_t type)
 		 * chance the first one is a false alarm and may not indicate
 		 * congestion.
 		 */
-		if (CCV(ccv, t_rxtshift) >= 2)
+		if (CCV(ccv, t_rxtshift) >= 2) {
 			cubic_data->num_cong_events++;
 			cubic_data->t_last_cong = ticks;
+		}
 		break;
 	}
 }


### PR DESCRIPTION
Fix this misleading indentation according to the upstream of freebsd.

Signed-off-by: Li Wei <liwei@anbutu.com>