### PR TITLE
fix NGX_EXCLUSIVE_EVENT compile error on linux 4.5+ and glibc 2.24+

### DIFF
--- a/app/nginx-1.11.10/auto/os/linux
+++ b/app/nginx-1.11.10/auto/os/linux
@@ -85,7 +85,7 @@ if [ $ngx_found = yes ]; then
                       ee.events = EPOLLIN|EPOLLEXCLUSIVE;
                       ee.data.ptr = NULL;
                       epoll_ctl(efd, EPOLL_CTL_ADD, fd, &ee)"
-    . auto/feature
+#    . auto/feature
 fi
 
 


### PR DESCRIPTION
if Linux >= 4.5 and glibc >= 2.24, will compile with EPOLLEXCLUSIVE, but FreeBSD does not supported EPOLLEXCLUSIVE.