### PR TITLE
Fix doc.

### DIFF
--- a/doc/F-Stack_Quick_Start_Guide.md
+++ b/doc/F-Stack_Quick_Start_Guide.md
@@ -44,8 +44,8 @@ The mount point can be made permanent across reboots, by adding the following li
 ## offload NIC
 
     modprobe uio
-    insmod /data/f-stack/dpdk/x86_64-native-linuxapp-gcc/build/kmod/igb_uio.ko
-    insmod /data/f-stack/dpdk/x86_64-native-linuxapp-gcc/build/kmod/rte_kni.ko
+    insmod /data/f-stack/dpdk/x86_64-native-linuxapp-gcc/kmod/igb_uio.ko
+    insmod /data/f-stack/dpdk/x86_64-native-linuxapp-gcc/kmod/rte_kni.ko
     python dpdk-devbind.py --status
     ifconfig eth0 down
     python dpdk-devbind.py --bind=igb_uio eth0 # assuming that use 10GE NIC and eth0


### PR DESCRIPTION
The path `/data/f-stack/dpdk/x86_64-native-linuxapp-gcc/build/kmod`
should be `/data/f-stack/dpdk/x86_64-native-linuxapp-gcc/kmod`

Fixes #54