### PR TITLE
redis: Use the ff_gettimeofday instead of gettimeofday.

### DIFF
--- a/app/redis-3.2.8/src/ae.c
+++ b/app/redis-3.2.8/src/ae.c
@@ -185,7 +185,12 @@ static void aeGetTime(long *seconds, long *milliseconds)
 {
     struct timeval tv;
 
+#ifdef HAVE_FF_KQUEUE
+    ff_gettimeofday(&tv, NULL);
+#else
     gettimeofday(&tv, NULL);
+#endif
+
     *seconds = tv.tv_sec;
     *milliseconds = tv.tv_usec/1000;
 }


### PR DESCRIPTION
In the redis, the gettimeofday uses too much CPU, even using the
vdso. This patch is useful to avoid wasting CPU cycles and
improve the performance.

Signed-off-by: Tonghao Zhang <xiangxia.m.yue@gmail.com>