### PR TITLE
add lvs toa option

### DIFF
--- a/freebsd/sys/socketvar.h
+++ b/freebsd/sys/socketvar.h
@@ -129,6 +129,9 @@ struct socket {
 
 	void *so_pspare[2];	/* packet pacing / general use */
 	int so_ispare[2];	/* packet pacing / general use */
+#ifdef LVS_TCPOPT_TOA
+	uint8_t so_toa[8];	/* lvs toa option */
+#endif
 };
 
 /*

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -94,6 +94,9 @@ endif
 
 CFLAGS+= -DFSTACK
 
+# add for LVS tcp option toa, disabled by default
+# CFLAGS+= -DLVS_TCPOPT_TOA
+
 VPATH+= $S/${MACHINE_CPUARCH}/${MACHINE_CPUARCH}
 VPATH+= $S/kern
 VPATH+= $S/crypto


### PR DESCRIPTION
A patch for lvs toa option enabled by CFLAGS+= -DLVS_TCPOPT_TOA 
It's disabled by default.
