### PR TITLE
issues #70 sysctl and netstat crash

### DIFF
--- a/tools/compat/ff_ipc.c
+++ b/tools/compat/ff_ipc.c
@@ -51,7 +51,7 @@ ff_set_proc_id(int pid)
     ff_proc_id = pid;
 }
 
-static int
+int
 ff_ipc_init(void)
 {
     if (inited) {

--- a/tools/compat/ff_ipc.h
+++ b/tools/compat/ff_ipc.h
@@ -32,6 +32,7 @@
 /* Set F-Stack proccess id to communicate with */
 void ff_set_proc_id(int pid);
 
+int ff_ipc_init(void);
 struct ff_msg *ff_ipc_msg_alloc(void);
 int ff_ipc_msg_free(struct ff_msg *msg);
 

--- a/tools/ifconfig/ifconfig.c
+++ b/tools/ifconfig/ifconfig.c
@@ -426,6 +426,8 @@ main(int argc, char *argv[])
 	struct option *p;
 	size_t iflen;
 
+	ff_ipc_init();
+
 	all = downonly = uponly = namesonly = noload = verbose = 0;
 	f_inet = f_inet6 = f_ether = f_addr = NULL;
 

--- a/tools/netstat/main.c
+++ b/tools/netstat/main.c
@@ -247,6 +247,8 @@ main(int argc, char *argv[])
 	char *endptr;
 	bool first = true;
 
+	ff_ipc_init();
+
 	af = AF_UNSPEC;
 
 	argc = xo_parse_args(argc, argv);

--- a/tools/route/route.c
+++ b/tools/route/route.c
@@ -281,6 +281,8 @@ main(int argc, char **argv)
 	if (argc < 2)
 		usage(NULL);
 
+	ff_ipc_init();
+
 #ifndef FSTACK
 	while ((ch = getopt(argc, argv, "46nqdtv")) != -1)
 #else

--- a/tools/sysctl/sysctl.c
+++ b/tools/sysctl/sysctl.c
@@ -241,6 +241,8 @@ main(int argc, char **argv)
 	int ch;
 	int warncount = 0;
 
+	ff_ipc_init();
+
 	setlocale(LC_NUMERIC, "");
 	setbuf(stdout,0);
 	setbuf(stderr,0);

--- a/tools/top/top.c
+++ b/tools/top/top.c
@@ -53,6 +53,8 @@ int main(int argc, char **argv)
     unsigned int i;
     struct ff_top_args top, otop;
 
+    ff_ipc_init();
+
 #define TOP_DIFF(member) (top.member - otop.member)
 
     while ((ch = getopt(argc, argv, "hp:d:n:")) != -1) {


### PR DESCRIPTION
base_addr != mcfg->memseg[s].addr
--
rte_eal_hugepage_init: 1618
(gdb) p  base_addr
$8 = (void *) 0x2aaab24df000
(gdb) p mcfg->memseg[s]
$9 = {phys_addr = 1472200704, {addr = 0x2aaaade00000, addr_64 = 46912549945344}, len = 2097152, 
  hugepage_sz = 2097152, socket_id = 0, nchannel = 0, nrank = 0}
(gdb) 


dpdk should init before mallocs.

issues #70 