### PR TITLE
ipfw: should init dpdk before all malloc

### DIFF
--- a/tools/ipfw/main.c
+++ b/tools/ipfw/main.c
@@ -646,7 +646,7 @@ main(int ac, char *av[])
 	 * If the last argument is an absolute pathname, interpret it
 	 * as a file to be preprocessed.
 	 */
-
+	ff_ipc_init();
 	if (ac > 1 && av[ac - 1][0] == '/') {
 		if (access(av[ac - 1], R_OK) == 0)
 			ipfw_readfile(ac, av);


### PR DESCRIPTION
Signed-off-by: Ji Bo <jibo@xdja.com>