### PR TITLE
 Nginx: support kernel network stack

### DIFF
--- a/app/nginx-1.11.10/auto/sources
+++ b/app/nginx-1.11.10/auto/sources
@@ -106,8 +106,8 @@ WIN32_SELECT_SRCS=src/event/modules/ngx_win32_select_module.c
 POLL_MODULE=ngx_poll_module
 POLL_SRCS=src/event/modules/ngx_poll_module.c
 
-KQUEUE_MODULE="ngx_kqueue_module ngx_ff_channel_module"
-KQUEUE_SRCS="src/event/modules/ngx_kqueue_module.c src/event/modules/ngx_ff_module.c src/event/modules/ngx_ff_channel.c"
+KQUEUE_MODULE="ngx_kqueue_module ngx_ff_host_event_module"
+KQUEUE_SRCS="src/event/modules/ngx_kqueue_module.c src/event/modules/ngx_ff_module.c src/event/modules/ngx_ff_host_event_module.c"
 
 DEVPOLL_MODULE=ngx_devpoll_module
 DEVPOLL_SRCS=src/event/modules/ngx_devpoll_module.c

--- a/app/nginx-1.11.10/conf/nginx.conf
+++ b/app/nginx-1.11.10/conf/nginx.conf
@@ -41,6 +41,10 @@ http {
         listen       80;
         server_name  localhost;
 
+        # bulid server on kernel network stack 
+        # 
+        #kernel_network_stack on;
+
         #charset koi8-r;
 
         access_log /dev/null;

--- a/app/nginx-1.11.10/src/core/ngx_connection.c
+++ b/app/nginx-1.11.10/src/core/ngx_connection.c
@@ -413,7 +413,7 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
             if (ngx_process <= NGX_PROCESS_MASTER) {
 
                 /* process master,  kernel network stack*/
-                if (!ls[i].belong_to_aeds) {
+                if (!ls[i].belong_to_host) {
                     /* We should continue to process the listening socket, 
                         if it is not supported by fstack.*/
                     if (fstack_territory(ls[i].sockaddr->sa_family, ls[i].type, 0)) {
@@ -422,7 +422,7 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
                 }
             } else if (NGX_PROCESS_WORKER == ngx_process) {
                 /* process worker, fstack */
-                if (ls[i].belong_to_aeds) {
+                if (ls[i].belong_to_host) {
                     continue;
                 }
 

--- a/app/nginx-1.11.10/src/core/ngx_connection.c
+++ b/app/nginx-1.11.10/src/core/ngx_connection.c
@@ -376,6 +376,10 @@ ngx_set_inherited_sockets(ngx_cycle_t *cycle)
     return NGX_OK;
 }
 
+#if (NGX_HAVE_FSTACK)
+extern int
+    fstack_territory(int domain, int type, int protocol);
+#endif
 
 ngx_int_t
 ngx_open_listening_sockets(ngx_cycle_t *cycle)
@@ -403,6 +407,36 @@ ngx_open_listening_sockets(ngx_cycle_t *cycle)
 
         ls = cycle->listening.elts;
         for (i = 0; i < cycle->listening.nelts; i++) {
+
+#if (NGX_HAVE_FSTACK)
+
+            if (ngx_process <= NGX_PROCESS_MASTER) {
+
+                /* process master,  kernel network stack*/
+                if (!ls[i].belong_to_aeds) {
+                    /* We should continue to process the listening socket, 
+                        if it is not supported by fstack.*/
+                    if (fstack_territory(ls[i].sockaddr->sa_family, ls[i].type, 0)) {
+                        continue;
+                    }
+                }
+            } else if (NGX_PROCESS_WORKER == ngx_process) {
+                /* process worker, fstack */
+                if (ls[i].belong_to_aeds) {
+                    continue;
+                }
+
+                if (!fstack_territory(ls[i].sockaddr->sa_family, ls[i].type, 0)) {
+                    continue;
+                }
+            } else {
+                ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
+                                  "unexpected process type: %d, ignored",
+                                  ngx_process);
+                exit(1);
+            }
+
+#endif
 
             if (ls[i].ignore) {
                 continue;
@@ -971,6 +1005,15 @@ ngx_close_listening_sockets(ngx_cycle_t *cycle)
     ls = cycle->listening.elts;
     for (i = 0; i < cycle->listening.nelts; i++) {
 
+#if (NGX_HAVE_FSTACK)
+
+        // No need to deal with, just skip
+        if (fstack_territory(ls[i].sockaddr->sa_family, ls[i].type, 0)) {
+            continue;
+        }
+
+#endif //(NGX_HAVE_FSTACK)
+
         c = ls[i].connection;
 
         if (c) {
@@ -1032,6 +1075,9 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
     ngx_uint_t         instance;
     ngx_event_t       *rev, *wev;
     ngx_connection_t  *c;
+#if (NGX_HAVE_FSTACK)
+    ngx_atomic_uint_t  success;
+#endif
 
     /* disable warning: Win32 SOCKET is u_int while UNIX socket is int */
 
@@ -1042,7 +1088,35 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
                       s, ngx_cycle->files_n);
         return NULL;
     }
+#if (NGX_HAVE_FSTACK)
+#ifndef unlikely
+#define unlikely(x)  __builtin_expect((x),0)
+#endif
+    /* move ngx_cycle->free_connections atomically */
+	do {
+		/* Restore n as it may change every loop */
+		c = ngx_cycle->free_connections;
 
+        if (c == NULL) {
+            ngx_drain_connections((ngx_cycle_t *) ngx_cycle);
+            c = ngx_cycle->free_connections;
+        }
+
+        if (c == NULL) {
+            ngx_log_error(NGX_LOG_ALERT, log, 0,
+                        "%ui worker_connections are not enough",
+                        ngx_cycle->connection_n);
+
+            return NULL;
+        }
+
+		success = ngx_atomic_cmp_set(&ngx_cycle->free_connections, c,
+					      c->data);
+
+	} while (unlikely(success == 0));
+
+	ngx_memory_barrier();
+#else
     c = ngx_cycle->free_connections;
 
     if (c == NULL) {
@@ -1059,6 +1133,7 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
     }
 
     ngx_cycle->free_connections = c->data;
+#endif
     ngx_cycle->free_connection_n--;
 
     if (ngx_cycle->files && ngx_cycle->files[s] == NULL) {
@@ -1098,8 +1173,25 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
 void
 ngx_free_connection(ngx_connection_t *c)
 {
-    c->data = ngx_cycle->free_connections;
+#if (NGX_HAVE_FSTACK)
+    ngx_atomic_uint_t  success;
+
+    /* move ngx_cycle->free_connections atomically */
+	do {
+		/* Restore n as it may change every loop */
+		c->data = ngx_cycle->free_connections;
+
+		success = ngx_atomic_cmp_set(&ngx_cycle->free_connections, c->data,
+					      c);
+
+	} while (unlikely(success == 0));
+
+	ngx_memory_barrier();
+
+#else
     ngx_cycle->free_connections = c;
+
+#endif
     ngx_cycle->free_connection_n++;
 
     if (ngx_cycle->files && ngx_cycle->files[c->fd] == c) {
@@ -1129,7 +1221,11 @@ ngx_close_connection(ngx_connection_t *c)
     }
 
     if (!c->shared) {
+#if (NGX_HAVE_FSTACK)
+        if (ngx_event_actions.del_conn) {
+#else
         if (ngx_del_conn) {
+#endif
             ngx_del_conn(c, NGX_CLOSE_EVENT);
 
         } else {

--- a/app/nginx-1.11.10/src/core/ngx_connection.h
+++ b/app/nginx-1.11.10/src/core/ngx_connection.h
@@ -88,7 +88,7 @@ struct ngx_listening_s {
 #endif
 
 #if (NGX_HAVE_FSTACK)
-    unsigned            belong_to_aeds:1;
+    unsigned            belong_to_host:1;
 #endif
 };
 

--- a/app/nginx-1.11.10/src/core/ngx_connection.h
+++ b/app/nginx-1.11.10/src/core/ngx_connection.h
@@ -87,6 +87,9 @@ struct ngx_listening_s {
     int                 fastopen;
 #endif
 
+#if (NGX_HAVE_FSTACK)
+    unsigned            belong_to_aeds:1;
+#endif
 };
 
 

--- a/app/nginx-1.11.10/src/core/ngx_cycle.c
+++ b/app/nginx-1.11.10/src/core/ngx_cycle.c
@@ -609,11 +609,9 @@ ngx_init_cycle(ngx_cycle_t *old_cycle)
         }
     }
 
-#if (!NGX_HAVE_FSTACK)
     if (ngx_open_listening_sockets(cycle) != NGX_OK) {
         goto failed;
     }
-#endif
 
     if (!ngx_test_config) {
         ngx_configure_listening_sockets(cycle);

--- a/app/nginx-1.11.10/src/core/ngx_resolver.c
+++ b/app/nginx-1.11.10/src/core/ngx_resolver.c
@@ -4512,7 +4512,11 @@ ngx_tcp_connect(ngx_resolver_connection_t *rec)
 
     c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
 
+#if (NGX_HAVE_FSTACK)
+    if (ngx_event_actions.add_conn) {
+#else
     if (ngx_add_conn) {
+#endif
         if (ngx_add_conn(c) == NGX_ERROR) {
             goto failed;
         }
@@ -4564,7 +4568,11 @@ ngx_tcp_connect(ngx_resolver_connection_t *rec)
         }
     }
 
+#if (NGX_HAVE_FSTACK)
+    if (ngx_event_actions.add_conn) {
+#else
     if (ngx_add_conn) {
+#endif
         if (rc == -1) {
 
             /* NGX_EINPROGRESS */

--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_channel.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_channel.c
@@ -567,7 +567,7 @@ ngx_ff_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd,
     rev->channel = 1;
     wev->channel = 1;
 
-    rev->belong_to_aeds = wev->belong_to_aeds = 1;
+    rev->belong_to_host = wev->belong_to_host = 1;
 
     ev = (event == NGX_READ_EVENT) ? rev : wev;
     ev->handler = handler;

--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_host_event_module.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_host_event_module.c
@@ -746,7 +746,7 @@ ngx_ff_start_worker_channel(ngx_cycle_t *cycle, ngx_fd_t fd,
     return NGX_OK;
 }
 
-ngx_event_actions_t   ngx_event_actions_dy = {
+ngx_event_actions_t   ngx_ff_host_event_actions = {
     ngx_ff_epoll_add_event,             /* add an event */
     ngx_ff_epoll_del_event,             /* delete an event */
     ngx_ff_epoll_add_event,             /* enable an event */

--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_host_event_module.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_host_event_module.c
@@ -56,10 +56,10 @@ static void ngx_ff_process_events_and_timers(ngx_cycle_t *cycle);
 ngx_int_t ngx_ff_start_worker_channel(ngx_cycle_t *cycle,
     ngx_fd_t fd, ngx_int_t event);
     
-void ngx_aeds_cancel_timers(void);
-void ngx_aeds_expire_timers(void);
-ngx_msec_t ngx_aeds_find_timer(void);
-void ngx_aeds_cancel_timers(void);
+void ngx_event_cancel_timers_of_host(void);
+void ngx_event_expire_timers_of_host(void);
+ngx_msec_t ngx_event_find_timer_of_host(void);
+void ngx_event_cancel_timers_of_host(void);
 
 struct channel_thread_args {
     ngx_cycle_t *cycle;
@@ -678,7 +678,7 @@ ngx_ff_host_event_thread_main(void *args)
         }
     }
 
-    ngx_aeds_cancel_timers();
+    ngx_event_cancel_timers_of_host();
 
     ngx_free(cta);
 
@@ -691,7 +691,7 @@ ngx_ff_process_events_and_timers(ngx_cycle_t *cycle)
     ngx_uint_t  flags;
     ngx_msec_t  timer, delta;
 
-    timer = ngx_aeds_find_timer();
+    timer = ngx_event_find_timer_of_host();
     flags = NGX_UPDATE_TIME;
 
     /* handle signals from master in case of network inactivity */
@@ -706,13 +706,13 @@ ngx_ff_process_events_and_timers(ngx_cycle_t *cycle)
 
     delta = ngx_current_msec - delta;
 
-    ngx_event_process_posted(cycle, &ngx_posted_accept_events_of_aeds);
+    ngx_event_process_posted(cycle, &ngx_posted_accept_events_of_host);
 
     if (delta) {
-        ngx_aeds_expire_timers();
+        ngx_event_expire_timers_of_host();
     }
 
-    ngx_event_process_posted(cycle, &ngx_posted_events_of_aeds);
+    ngx_event_process_posted(cycle, &ngx_posted_events_of_host);
 
 }
 

--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
@@ -152,6 +152,10 @@ static inline int restore_fstack_fd(int sockfd) {
 
 /* Tell whether a 'sockfd' belongs to fstack. */
 static inline int is_fstack_fd(int sockfd) {
+    if (unlikely(inited == 0)) {
+        return 0;
+    }
+
     return sockfd >= ngx_max_sockets;
 }
 

--- a/app/nginx-1.11.10/src/event/ngx_event.c
+++ b/app/nginx-1.11.10/src/event/ngx_event.c
@@ -608,8 +608,8 @@ ngx_event_process_init(ngx_cycle_t *cycle)
     ngx_queue_init(&ngx_posted_events);
 
 #if (NGX_HAVE_FSTACK)
-    ngx_queue_init(&ngx_posted_accept_events_of_aeds);
-    ngx_queue_init(&ngx_posted_events_of_aeds);
+    ngx_queue_init(&ngx_posted_accept_events_of_host);
+    ngx_queue_init(&ngx_posted_events_of_host);
 #endif
 
     if (ngx_event_timer_init(cycle->log) == NGX_ERROR) {

--- a/app/nginx-1.11.10/src/event/ngx_event.c
+++ b/app/nginx-1.11.10/src/event/ngx_event.c
@@ -566,7 +566,7 @@ ngx_timer_signal_handler(int signo)
 
 #if (NGX_HAVE_FSTACK)
 
-extern ngx_event_actions_t   ngx_event_actions_dy;
+extern ngx_event_actions_t   ngx_ff_host_event_actions;
 
 #endif
 
@@ -636,7 +636,7 @@ ngx_event_process_init(ngx_cycle_t *cycle)
     }
 
 #if (NGX_HAVE_FSTACK)
-    if (ngx_event_actions_dy.init(cycle, ngx_timer_resolution) != NGX_OK) {
+    if (ngx_ff_host_event_actions.init(cycle, ngx_timer_resolution) != NGX_OK) {
         /* fatal */
         exit(2);
     }

--- a/app/nginx-1.11.10/src/event/ngx_event.c
+++ b/app/nginx-1.11.10/src/event/ngx_event.c
@@ -783,7 +783,7 @@ ngx_event_process_init(ngx_cycle_t *cycle)
 #if (NGX_HAVE_FSTACK)
         /* Note when nginx running on fstack, 
             make sure that add the right fd to kqueue !! */
-		c->read->belong_to_aeds = c->write->belong_to_aeds = ls[i].belong_to_aeds;
+		c->read->belong_to_host = c->write->belong_to_host = ls[i].belong_to_host;
 #endif
 
 #if (NGX_HAVE_DEFERRED_ACCEPT)

--- a/app/nginx-1.11.10/src/event/ngx_event.h
+++ b/app/nginx-1.11.10/src/event/ngx_event.h
@@ -415,55 +415,55 @@ extern ngx_event_actions_t   ngx_ff_host_event_actions;
 
 #if (NGX_HAVE_FSTACK)
 
-    static inline ngx_int_t
-    ngx_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
-        if (1 == ev->belong_to_host) {
-            return ngx_ff_host_event_actions.add(ev, event, flags);
-        } else {
-            return ngx_event_actions.add(ev, event, flags);
-        }
+static inline ngx_int_t
+ngx_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
+    if (1 == ev->belong_to_host) {
+        return ngx_ff_host_event_actions.add(ev, event, flags);
+    } else {
+        return ngx_event_actions.add(ev, event, flags);
     }
+}
 
-    static inline ngx_int_t
-    ngx_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
-        if (1 == ev->belong_to_host) {
-            return ngx_ff_host_event_actions.del(ev, event, flags);
-        } else {
-            return ngx_event_actions.del(ev, event, flags);
-        }
+static inline ngx_int_t
+ngx_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
+    if (1 == ev->belong_to_host) {
+        return ngx_ff_host_event_actions.del(ev, event, flags);
+    } else {
+        return ngx_event_actions.del(ev, event, flags);
     }
+}
 
-    static inline ngx_int_t ngx_add_conn(ngx_connection_t *c)
-    {
-        return ngx_event_actions.add_conn(c);
-    }
+static inline ngx_int_t ngx_add_conn(ngx_connection_t *c)
+{
+    return ngx_event_actions.add_conn(c);
+}
 
-    static inline ngx_int_t ngx_del_conn(
-        ngx_connection_t *c, ngx_uint_t flags) {
-        return ngx_event_actions.del_conn(c, flags);
-    }
+static inline ngx_int_t ngx_del_conn(
+    ngx_connection_t *c, ngx_uint_t flags) {
+    return ngx_event_actions.del_conn(c, flags);
+}
 
-    static inline ngx_int_t ngx_notify(ngx_event_handler_pt handler) {
-        return ngx_event_actions.notify(handler);
-    }
+static inline ngx_int_t ngx_notify(ngx_event_handler_pt handler) {
+    return ngx_event_actions.notify(handler);
+}
 
-    static inline ngx_int_t ngx_process_events(
-        ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
-    {
-        return ngx_event_actions.process_events(cycle, timer, flags);
-    }
+static inline ngx_int_t ngx_process_events(
+    ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
+{
+    return ngx_event_actions.process_events(cycle, timer, flags);
+}
 
 #else
 
-    #define ngx_process_events   ngx_event_actions.process_events
-    #define ngx_done_events      ngx_event_actions.done
+#define ngx_process_events   ngx_event_actions.process_events
+#define ngx_done_events      ngx_event_actions.done
 
-    #define ngx_add_event        ngx_event_actions.add
-    #define ngx_del_event        ngx_event_actions.del
-    #define ngx_add_conn         ngx_event_actions.add_conn
-    #define ngx_del_conn         ngx_event_actions.del_conn
+#define ngx_add_event        ngx_event_actions.add
+#define ngx_del_event        ngx_event_actions.del
+#define ngx_add_conn         ngx_event_actions.add_conn
+#define ngx_del_conn         ngx_event_actions.del_conn
 
-    #define ngx_notify           ngx_event_actions.notify
+#define ngx_notify           ngx_event_actions.notify
 
 #endif
 

--- a/app/nginx-1.11.10/src/event/ngx_event.h
+++ b/app/nginx-1.11.10/src/event/ngx_event.h
@@ -203,7 +203,7 @@ extern ngx_event_actions_t   ngx_event_actions;
 extern ngx_uint_t            ngx_use_epoll_rdhup;
 #endif
 #if (NGX_HAVE_FSTACK)
-extern ngx_event_actions_t   ngx_event_actions_dy;
+extern ngx_event_actions_t   ngx_ff_host_event_actions;
 #endif
 
 /*
@@ -418,7 +418,7 @@ extern ngx_event_actions_t   ngx_event_actions_dy;
     static inline ngx_int_t
     ngx_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
         if (1 == ev->belong_to_host) {
-            return ngx_event_actions_dy.add(ev, event, flags);
+            return ngx_ff_host_event_actions.add(ev, event, flags);
         } else {
             return ngx_event_actions.add(ev, event, flags);
         }
@@ -427,7 +427,7 @@ extern ngx_event_actions_t   ngx_event_actions_dy;
     static inline ngx_int_t
     ngx_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
         if (1 == ev->belong_to_host) {
-            return ngx_event_actions_dy.del(ev, event, flags);
+            return ngx_ff_host_event_actions.del(ev, event, flags);
         } else {
             return ngx_event_actions.del(ev, event, flags);
         }

--- a/app/nginx-1.11.10/src/event/ngx_event.h
+++ b/app/nginx-1.11.10/src/event/ngx_event.h
@@ -144,7 +144,7 @@ struct ngx_event_s {
 #endif
 
 #if (NGX_HAVE_FSTACK)
-    unsigned        belong_to_aeds:1;
+    unsigned        belong_to_host:1;
 #endif
 };
 
@@ -417,7 +417,7 @@ extern ngx_event_actions_t   ngx_event_actions_dy;
 
     static inline ngx_int_t
     ngx_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
-        if (1 == ev->belong_to_aeds) {
+        if (1 == ev->belong_to_host) {
             return ngx_event_actions_dy.add(ev, event, flags);
         } else {
             return ngx_event_actions.add(ev, event, flags);
@@ -426,7 +426,7 @@ extern ngx_event_actions_t   ngx_event_actions_dy;
 
     static inline ngx_int_t
     ngx_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
-        if (1 == ev->belong_to_aeds) {
+        if (1 == ev->belong_to_host) {
             return ngx_event_actions_dy.del(ev, event, flags);
         } else {
             return ngx_event_actions.del(ev, event, flags);

--- a/app/nginx-1.11.10/src/event/ngx_event.h
+++ b/app/nginx-1.11.10/src/event/ngx_event.h
@@ -142,6 +142,10 @@ struct ngx_event_s {
     uint32_t         padding[NGX_EVENT_T_PADDING];
 #endif
 #endif
+
+#if (NGX_HAVE_FSTACK)
+    unsigned        belong_to_aeds:1;
+#endif
 };
 
 
@@ -198,7 +202,9 @@ extern ngx_event_actions_t   ngx_event_actions;
 #if (NGX_HAVE_EPOLLRDHUP)
 extern ngx_uint_t            ngx_use_epoll_rdhup;
 #endif
-
+#if (NGX_HAVE_FSTACK)
+extern ngx_event_actions_t   ngx_event_actions_dy;
+#endif
 
 /*
  * The event filter requires to read/write the whole data:
@@ -407,16 +413,59 @@ extern ngx_uint_t            ngx_use_epoll_rdhup;
 #define NGX_CLEAR_EVENT    0    /* dummy declaration */
 #endif
 
+#if (NGX_HAVE_FSTACK)
 
-#define ngx_process_events   ngx_event_actions.process_events
-#define ngx_done_events      ngx_event_actions.done
+    static inline ngx_int_t
+    ngx_add_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
+        if (1 == ev->belong_to_aeds) {
+            return ngx_event_actions_dy.add(ev, event, flags);
+        } else {
+            return ngx_event_actions.add(ev, event, flags);
+        }
+    }
 
-#define ngx_add_event        ngx_event_actions.add
-#define ngx_del_event        ngx_event_actions.del
-#define ngx_add_conn         ngx_event_actions.add_conn
-#define ngx_del_conn         ngx_event_actions.del_conn
+    static inline ngx_int_t
+    ngx_del_event(ngx_event_t *ev, ngx_int_t event, ngx_uint_t flags) {
+        if (1 == ev->belong_to_aeds) {
+            return ngx_event_actions_dy.del(ev, event, flags);
+        } else {
+            return ngx_event_actions.del(ev, event, flags);
+        }
+    }
 
-#define ngx_notify           ngx_event_actions.notify
+    static inline ngx_int_t ngx_add_conn(ngx_connection_t *c)
+    {
+        return ngx_event_actions.add_conn(c);
+    }
+
+    static inline ngx_int_t ngx_del_conn(
+        ngx_connection_t *c, ngx_uint_t flags) {
+        return ngx_event_actions.del_conn(c, flags);
+    }
+
+    static inline ngx_int_t ngx_notify(ngx_event_handler_pt handler) {
+        return ngx_event_actions.notify(handler);
+    }
+
+    static inline ngx_int_t ngx_process_events(
+        ngx_cycle_t *cycle, ngx_msec_t timer, ngx_uint_t flags)
+    {
+        return ngx_event_actions.process_events(cycle, timer, flags);
+    }
+
+#else
+
+    #define ngx_process_events   ngx_event_actions.process_events
+    #define ngx_done_events      ngx_event_actions.done
+
+    #define ngx_add_event        ngx_event_actions.add
+    #define ngx_del_event        ngx_event_actions.del
+    #define ngx_add_conn         ngx_event_actions.add_conn
+    #define ngx_del_conn         ngx_event_actions.del_conn
+
+    #define ngx_notify           ngx_event_actions.notify
+
+#endif
 
 #define ngx_add_timer        ngx_event_add_timer
 #define ngx_del_timer        ngx_event_del_timer

--- a/app/nginx-1.11.10/src/event/ngx_event_accept.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_accept.c
@@ -231,7 +231,7 @@ ngx_event_accept(ngx_event_t *ev)
         wev = c->write;
 
 #if (NGX_HAVE_FSTACK)
-        rev->belong_to_aeds = wev->belong_to_aeds = ev->belong_to_aeds;
+        rev->belong_to_host = wev->belong_to_host = ev->belong_to_host;
 #endif
 
         wev->ready = 1;

--- a/app/nginx-1.11.10/src/event/ngx_event_accept.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_accept.c
@@ -230,6 +230,10 @@ ngx_event_accept(ngx_event_t *ev)
         rev = c->read;
         wev = c->write;
 
+#if (NGX_HAVE_FSTACK)
+        rev->belong_to_aeds = wev->belong_to_aeds = ev->belong_to_aeds;
+#endif
+
         wev->ready = 1;
 
         if (ngx_event_flags & NGX_USE_IOCP_EVENT) {
@@ -296,7 +300,11 @@ ngx_event_accept(ngx_event_t *ev)
         }
 #endif
 
+#if (NGX_HAVE_FSTACK)
+        if (ngx_event_actions.add_conn && (ngx_event_flags & NGX_USE_EPOLL_EVENT) == 0) {
+#else
         if (ngx_add_conn && (ngx_event_flags & NGX_USE_EPOLL_EVENT) == 0) {
+#endif
             if (ngx_add_conn(c) == NGX_ERROR) {
                 ngx_close_accepted_connection(c);
                 return;
@@ -432,6 +440,7 @@ ngx_event_recvmsg(ngx_event_t *ev)
                               - ngx_cycle->free_connection_n;
 
         c = ngx_get_connection(lc->fd, ev->log);
+
         if (c == NULL) {
             return;
         }

--- a/app/nginx-1.11.10/src/event/ngx_event_connect.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.c
@@ -181,7 +181,11 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
 
     c->number = ngx_atomic_fetch_add(ngx_connection_counter, 1);
 
+#if (NGX_HAVE_FSTACK)
+    if (ngx_event_actions.add_conn) {
+#else
     if (ngx_add_conn) {
+#endif
         if (ngx_add_conn(c) == NGX_ERROR) {
             goto failed;
         }
@@ -233,7 +237,11 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
         }
     }
 
+#if (NGX_HAVE_FSTACK)
+    if (ngx_event_actions.add_conn) {
+#else
     if (ngx_add_conn) {
+#endif
         if (rc == -1) {
 
             /* NGX_EINPROGRESS */

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.c
@@ -13,6 +13,11 @@
 ngx_queue_t  ngx_posted_accept_events;
 ngx_queue_t  ngx_posted_events;
 
+#if (NGX_HAVE_FSTACK)
+ngx_queue_t  ngx_posted_accept_events_of_aeds;
+ngx_queue_t  ngx_posted_events_of_aeds;
+#endif
+
 
 void
 ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted)

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.c
@@ -14,8 +14,8 @@ ngx_queue_t  ngx_posted_accept_events;
 ngx_queue_t  ngx_posted_events;
 
 #if (NGX_HAVE_FSTACK)
-ngx_queue_t  ngx_posted_accept_events_of_aeds;
-ngx_queue_t  ngx_posted_events_of_aeds;
+ngx_queue_t  ngx_posted_accept_events_of_host;
+ngx_queue_t  ngx_posted_events_of_host;
 #endif
 
 

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.h
@@ -19,7 +19,7 @@
                                                                               \
     if (!(ev)->posted) {                                                      \
         (ev)->posted = 1;                                                     \
-        if (1 == (ev)->belong_to_aeds) {                                      \
+        if (1 == (ev)->belong_to_host) {                                      \
             if (q == &ngx_posted_events) {                                    \
                 ngx_queue_insert_tail(                                        \
                     &ngx_posted_events_of_aeds, &(ev)->queue);                \

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.h
@@ -14,6 +14,34 @@
 #include <ngx_event.h>
 
 
+#if (NGX_HAVE_FSTACK)
+#define ngx_post_event(ev, q)                                                 \
+                                                                              \
+    if (!(ev)->posted) {                                                      \
+        (ev)->posted = 1;                                                     \
+        if (1 == (ev)->belong_to_aeds) {                                      \
+            if (q == &ngx_posted_events) {                                    \
+                ngx_queue_insert_tail(                                        \
+                    &ngx_posted_events_of_aeds, &(ev)->queue);                \
+            } else if (q == &ngx_posted_accept_events) {                      \
+                ngx_queue_insert_tail(                                        \
+                    &ngx_posted_accept_events_of_aeds, &(ev)->queue);         \
+            } else {                                                          \
+                ngx_log_error(NGX_LOG_EMERG, (ev)->log, 0,                    \
+                          "ngx_post_event: unkowned posted queue");           \
+                exit(1);                                                      \
+            }                                                                 \
+        } else {                                                              \
+            ngx_queue_insert_tail(q, &(ev)->queue);                           \
+        }                                                                     \
+                                                                              \
+        ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0, "post event %p", ev);\
+                                                                              \
+    } else  {                                                                 \
+        ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0,                      \
+                       "update posted event %p", ev);                         \
+    }
+#else
 #define ngx_post_event(ev, q)                                                 \
                                                                               \
     if (!(ev)->posted) {                                                      \
@@ -26,6 +54,7 @@
         ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0,                      \
                        "update posted event %p", ev);                         \
     }
+#endif
 
 
 #define ngx_delete_posted_event(ev)                                           \
@@ -44,5 +73,9 @@ void ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted);
 extern ngx_queue_t  ngx_posted_accept_events;
 extern ngx_queue_t  ngx_posted_events;
 
+#if (NGX_HAVE_FSTACK)
+extern ngx_queue_t  ngx_posted_accept_events_of_aeds;
+extern ngx_queue_t  ngx_posted_events_of_aeds;
+#endif
 
 #endif /* _NGX_EVENT_POSTED_H_INCLUDED_ */

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.h
@@ -22,10 +22,10 @@
         if (1 == (ev)->belong_to_host) {                                      \
             if (q == &ngx_posted_events) {                                    \
                 ngx_queue_insert_tail(                                        \
-                    &ngx_posted_events_of_aeds, &(ev)->queue);                \
+                    &ngx_posted_events_of_host, &(ev)->queue);                \
             } else if (q == &ngx_posted_accept_events) {                      \
                 ngx_queue_insert_tail(                                        \
-                    &ngx_posted_accept_events_of_aeds, &(ev)->queue);         \
+                    &ngx_posted_accept_events_of_host, &(ev)->queue);         \
             } else {                                                          \
                 ngx_log_error(NGX_LOG_EMERG, (ev)->log, 0,                    \
                           "ngx_post_event: unkowned posted queue");           \
@@ -74,8 +74,8 @@ extern ngx_queue_t  ngx_posted_accept_events;
 extern ngx_queue_t  ngx_posted_events;
 
 #if (NGX_HAVE_FSTACK)
-extern ngx_queue_t  ngx_posted_accept_events_of_aeds;
-extern ngx_queue_t  ngx_posted_events_of_aeds;
+extern ngx_queue_t  ngx_posted_accept_events_of_host;
+extern ngx_queue_t  ngx_posted_events_of_host;
 #endif
 
 #endif /* _NGX_EVENT_POSTED_H_INCLUDED_ */

--- a/app/nginx-1.11.10/src/event/ngx_event_timer.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_timer.c
@@ -13,6 +13,11 @@
 ngx_rbtree_t              ngx_event_timer_rbtree;
 static ngx_rbtree_node_t  ngx_event_timer_sentinel;
 
+#if (NGX_HAVE_FSTACK)
+ngx_rbtree_t              ngx_aeds_timer_rbtree;
+static ngx_rbtree_node_t  ngx_aeds_timer_sentinel;
+#endif
+
 /*
  * the event timer rbtree may contain the duplicate keys, however,
  * it should not be a problem, because we use the rbtree to find
@@ -25,22 +30,54 @@ ngx_event_timer_init(ngx_log_t *log)
     ngx_rbtree_init(&ngx_event_timer_rbtree, &ngx_event_timer_sentinel,
                     ngx_rbtree_insert_timer_value);
 
+#if (NGX_HAVE_FSTACK)
+
+    ngx_rbtree_init(&ngx_aeds_timer_rbtree, &ngx_aeds_timer_sentinel,
+                    ngx_rbtree_insert_timer_value);
+
+#endif
+
     return NGX_OK;
 }
 
 
+#if (NGX_HAVE_FSTACK)
+
+ngx_msec_t
+ngx_event_find_timer_internal(
+    ngx_rbtree_t *rbtree, ngx_rbtree_node_t *sentinel);
 ngx_msec_t
 ngx_event_find_timer(void)
 {
+    return ngx_event_find_timer_internal(&ngx_event_timer_rbtree, &ngx_event_timer_sentinel);
+}
+
+ngx_msec_t
+ngx_aeds_find_timer(void)
+{
+    return ngx_event_find_timer_internal(&ngx_aeds_timer_rbtree, &ngx_aeds_timer_sentinel);
+}
+
+ngx_msec_t
+ngx_event_find_timer_internal(
+    ngx_rbtree_t *rbtree, ngx_rbtree_node_t *rbtree_sentinel)
+{
+#else
+ngx_msec_t
+ngx_event_find_timer(void)
+{
+    ngx_rbtree_t * rbtree = &ngx_event_timer_rbtree;
+    ngx_rbtree_node_t *rbtree_sentinel = &ngx_event_timer_sentinel;
+#endif
     ngx_msec_int_t      timer;
     ngx_rbtree_node_t  *node, *root, *sentinel;
 
-    if (ngx_event_timer_rbtree.root == &ngx_event_timer_sentinel) {
+    if (rbtree->root == rbtree_sentinel) {
         return NGX_TIMER_INFINITE;
     }
 
-    root = ngx_event_timer_rbtree.root;
-    sentinel = ngx_event_timer_rbtree.sentinel;
+    root = rbtree->root;
+    sentinel = rbtree->sentinel;
 
     node = ngx_rbtree_min(root, sentinel);
 
@@ -50,16 +87,39 @@ ngx_event_find_timer(void)
 }
 
 
+#if (NGX_HAVE_FSTACK)
+
+void
+ngx_event_expire_timers_internal(ngx_rbtree_t *rbtree);
+
 void
 ngx_event_expire_timers(void)
 {
+    ngx_event_expire_timers_internal(&ngx_event_timer_rbtree);
+}
+
+void
+ngx_aeds_expire_timers(void)
+{
+    ngx_event_expire_timers_internal(&ngx_aeds_timer_rbtree);
+}
+
+void
+ngx_event_expire_timers_internal(ngx_rbtree_t *rbtree)
+{
+#else
+void
+ngx_event_expire_timers(void)
+{
+    ngx_rbtree_t * rbtree = &ngx_event_timer_rbtree;
+#endif
     ngx_event_t        *ev;
     ngx_rbtree_node_t  *node, *root, *sentinel;
 
-    sentinel = ngx_event_timer_rbtree.sentinel;
+    sentinel = rbtree->sentinel;
 
     for ( ;; ) {
-        root = ngx_event_timer_rbtree.root;
+        root = rbtree->root;
 
         if (root == sentinel) {
             return;
@@ -79,7 +139,7 @@ ngx_event_expire_timers(void)
                        "event timer del: %d: %M",
                        ngx_event_ident(ev->data), ev->timer.key);
 
-        ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
+        ngx_rbtree_delete(rbtree, &ev->timer);
 
 #if (NGX_DEBUG)
         ev->timer.left = NULL;
@@ -96,16 +156,39 @@ ngx_event_expire_timers(void)
 }
 
 
+#if (NGX_HAVE_FSTACK)
+
+void
+ngx_event_cancel_timers_internal(ngx_rbtree_t *rbtree);
+
 void
 ngx_event_cancel_timers(void)
 {
+    ngx_event_cancel_timers_internal(&ngx_event_timer_rbtree);
+}
+
+void
+ngx_aeds_cancel_timers(void)
+{
+    ngx_event_cancel_timers_internal(&ngx_aeds_timer_rbtree);
+}
+
+void
+ngx_event_cancel_timers_internal(ngx_rbtree_t *rbtree)
+{
+#else
+void
+ngx_event_cancel_timers(void)
+{
+    ngx_rbtree_t * rbtree = &ngx_event_timer_rbtree;
+#endif
     ngx_event_t        *ev;
     ngx_rbtree_node_t  *node, *root, *sentinel;
 
-    sentinel = ngx_event_timer_rbtree.sentinel;
+    sentinel = rbtree->sentinel;
 
     for ( ;; ) {
-        root = ngx_event_timer_rbtree.root;
+        root = rbtree->root;
 
         if (root == sentinel) {
             return;
@@ -123,7 +206,7 @@ ngx_event_cancel_timers(void)
                        "event timer cancel: %d: %M",
                        ngx_event_ident(ev->data), ev->timer.key);
 
-        ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
+        ngx_rbtree_delete(rbtree, &ev->timer);
 
 #if (NGX_DEBUG)
         ev->timer.left = NULL;

--- a/app/nginx-1.11.10/src/event/ngx_event_timer.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_timer.c
@@ -14,8 +14,8 @@ ngx_rbtree_t              ngx_event_timer_rbtree;
 static ngx_rbtree_node_t  ngx_event_timer_sentinel;
 
 #if (NGX_HAVE_FSTACK)
-ngx_rbtree_t              ngx_aeds_timer_rbtree;
-static ngx_rbtree_node_t  ngx_aeds_timer_sentinel;
+ngx_rbtree_t              ngx_event_timer_rbtree_of_host;
+static ngx_rbtree_node_t  ngx_event_timer_sentinel_of_host;
 #endif
 
 /*
@@ -32,7 +32,7 @@ ngx_event_timer_init(ngx_log_t *log)
 
 #if (NGX_HAVE_FSTACK)
 
-    ngx_rbtree_init(&ngx_aeds_timer_rbtree, &ngx_aeds_timer_sentinel,
+    ngx_rbtree_init(&ngx_event_timer_rbtree_of_host, &ngx_event_timer_sentinel_of_host,
                     ngx_rbtree_insert_timer_value);
 
 #endif
@@ -53,9 +53,9 @@ ngx_event_find_timer(void)
 }
 
 ngx_msec_t
-ngx_aeds_find_timer(void)
+ngx_event_find_timer_of_host(void)
 {
-    return ngx_event_find_timer_internal(&ngx_aeds_timer_rbtree, &ngx_aeds_timer_sentinel);
+    return ngx_event_find_timer_internal(&ngx_event_timer_rbtree_of_host, &ngx_event_timer_sentinel_of_host);
 }
 
 ngx_msec_t
@@ -99,9 +99,9 @@ ngx_event_expire_timers(void)
 }
 
 void
-ngx_aeds_expire_timers(void)
+ngx_event_expire_timers_of_host(void)
 {
-    ngx_event_expire_timers_internal(&ngx_aeds_timer_rbtree);
+    ngx_event_expire_timers_internal(&ngx_event_timer_rbtree_of_host);
 }
 
 void
@@ -168,9 +168,9 @@ ngx_event_cancel_timers(void)
 }
 
 void
-ngx_aeds_cancel_timers(void)
+ngx_event_cancel_timers_of_host(void)
 {
-    ngx_event_cancel_timers_internal(&ngx_aeds_timer_rbtree);
+    ngx_event_cancel_timers_internal(&ngx_event_timer_rbtree_of_host);
 }
 
 void

--- a/app/nginx-1.11.10/src/event/ngx_event_timer.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_timer.h
@@ -27,6 +27,9 @@ void ngx_event_cancel_timers(void);
 
 extern ngx_rbtree_t  ngx_event_timer_rbtree;
 
+#if (NGX_HAVE_FSTACK)
+extern ngx_rbtree_t  ngx_aeds_timer_rbtree;
+#endif
 
 static ngx_inline void
 ngx_event_del_timer(ngx_event_t *ev)
@@ -35,7 +38,19 @@ ngx_event_del_timer(ngx_event_t *ev)
                    "event timer del: %d: %M",
                     ngx_event_ident(ev->data), ev->timer.key);
 
+#if (NGX_HAVE_FSTACK)
+
+    if(ev->belong_to_aeds){
+        ngx_rbtree_delete(&ngx_aeds_timer_rbtree, &ev->timer);
+    } else {
+        ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
+    }
+
+#else
+
     ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
+
+#endif
 
 #if (NGX_DEBUG)
     ev->timer.left = NULL;
@@ -81,7 +96,19 @@ ngx_event_add_timer(ngx_event_t *ev, ngx_msec_t timer)
                    "event timer add: %d: %M:%M",
                     ngx_event_ident(ev->data), timer, ev->timer.key);
 
+#if (NGX_HAVE_FSTACK)
+
+    if(ev->belong_to_aeds){
+        ngx_rbtree_insert(&ngx_aeds_timer_rbtree, &ev->timer);
+    } else {
+        ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);
+    }
+
+#else
+
     ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);
+
+#endif
 
     ev->timer_set = 1;
 }

--- a/app/nginx-1.11.10/src/event/ngx_event_timer.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_timer.h
@@ -40,7 +40,7 @@ ngx_event_del_timer(ngx_event_t *ev)
 
 #if (NGX_HAVE_FSTACK)
 
-    if(ev->belong_to_aeds){
+    if(ev->belong_to_host){
         ngx_rbtree_delete(&ngx_aeds_timer_rbtree, &ev->timer);
     } else {
         ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
@@ -98,7 +98,7 @@ ngx_event_add_timer(ngx_event_t *ev, ngx_msec_t timer)
 
 #if (NGX_HAVE_FSTACK)
 
-    if(ev->belong_to_aeds){
+    if(ev->belong_to_host){
         ngx_rbtree_insert(&ngx_aeds_timer_rbtree, &ev->timer);
     } else {
         ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);

--- a/app/nginx-1.11.10/src/event/ngx_event_timer.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_timer.h
@@ -28,7 +28,7 @@ void ngx_event_cancel_timers(void);
 extern ngx_rbtree_t  ngx_event_timer_rbtree;
 
 #if (NGX_HAVE_FSTACK)
-extern ngx_rbtree_t  ngx_aeds_timer_rbtree;
+extern ngx_rbtree_t  ngx_event_timer_rbtree_of_host;
 #endif
 
 static ngx_inline void
@@ -41,7 +41,7 @@ ngx_event_del_timer(ngx_event_t *ev)
 #if (NGX_HAVE_FSTACK)
 
     if(ev->belong_to_host){
-        ngx_rbtree_delete(&ngx_aeds_timer_rbtree, &ev->timer);
+        ngx_rbtree_delete(&ngx_event_timer_rbtree_of_host, &ev->timer);
     } else {
         ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
     }
@@ -99,7 +99,7 @@ ngx_event_add_timer(ngx_event_t *ev, ngx_msec_t timer)
 #if (NGX_HAVE_FSTACK)
 
     if(ev->belong_to_host){
-        ngx_rbtree_insert(&ngx_aeds_timer_rbtree, &ev->timer);
+        ngx_rbtree_insert(&ngx_event_timer_rbtree_of_host, &ev->timer);
     } else {
         ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);
     }

--- a/app/nginx-1.11.10/src/http/ngx_http.c
+++ b/app/nginx-1.11.10/src/http/ngx_http.c
@@ -1776,7 +1776,7 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
 #endif
 
 #if (NGX_HAVE_FSTACK)
-    ls->belong_to_aeds = cscf->kernel_network_stack;
+    ls->belong_to_host = cscf->kernel_network_stack;
 #endif
 
     return ls;

--- a/app/nginx-1.11.10/src/http/ngx_http.c
+++ b/app/nginx-1.11.10/src/http/ngx_http.c
@@ -1775,6 +1775,10 @@ ngx_http_add_listening(ngx_conf_t *cf, ngx_http_conf_addr_t *addr)
     ls->reuseport = addr->opt.reuseport;
 #endif
 
+#if (NGX_HAVE_FSTACK)
+    ls->belong_to_aeds = cscf->kernel_network_stack;
+#endif
+
     return ls;
 }
 

--- a/app/nginx-1.11.10/src/http/ngx_http_core_module.c
+++ b/app/nginx-1.11.10/src/http/ngx_http_core_module.c
@@ -293,6 +293,17 @@ static ngx_command_t  ngx_http_core_commands[] = {
       0,
       NULL },
 
+#if (NGX_HAVE_FSTACK)
+
+    { ngx_string("kernel_network_stack"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_core_srv_conf_t, kernel_network_stack),
+      NULL },
+
+#endif
+
     { ngx_string("types_hash_max_size"),
       NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_HTTP_LOC_CONF|NGX_CONF_TAKE1,
       ngx_conf_set_num_slot,
@@ -3444,6 +3455,7 @@ ngx_http_core_create_srv_conf(ngx_conf_t *cf)
     cscf->ignore_invalid_headers = NGX_CONF_UNSET;
     cscf->merge_slashes = NGX_CONF_UNSET;
     cscf->underscores_in_headers = NGX_CONF_UNSET;
+    cscf->kernel_network_stack = NGX_CONF_UNSET;
 
     return cscf;
 }
@@ -3486,6 +3498,12 @@ ngx_http_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_value(conf->underscores_in_headers,
                               prev->underscores_in_headers, 0);
+
+#if (NGX_HAVE_FSTACK)
+    /* By default, we set up a server on fstack */
+    ngx_conf_merge_value(conf->kernel_network_stack,
+                              prev->kernel_network_stack, 0);
+#endif
 
     if (conf->server_names.nelts == 0) {
         /* the array has 4 empty preallocated elements, so push cannot fail */

--- a/app/nginx-1.11.10/src/http/ngx_http_core_module.h
+++ b/app/nginx-1.11.10/src/http/ngx_http_core_module.h
@@ -199,6 +199,10 @@ typedef struct {
     ngx_flag_t                  merge_slashes;
     ngx_flag_t                  underscores_in_headers;
 
+#if (NGX_HAVE_FSTACK)
+    ngx_flag_t                  kernel_network_stack;    /* kernel_network_stack */
+#endif
+
     unsigned                    listen:1;
 #if (NGX_PCRE)
     unsigned                    captures:1;

--- a/app/nginx-1.11.10/src/mail/ngx_mail.c
+++ b/app/nginx-1.11.10/src/mail/ngx_mail.c
@@ -345,6 +345,10 @@ ngx_mail_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
             ls->ipv6only = addr[i].opt.ipv6only;
 #endif
 
+#if (NGX_HAVE_FSTACK)
+            ls->belong_to_aeds = cscf->kernel_network_stack;
+#endif
+
             mport = ngx_palloc(cf->pool, sizeof(ngx_mail_port_t));
             if (mport == NULL) {
                 return NGX_CONF_ERROR;

--- a/app/nginx-1.11.10/src/mail/ngx_mail.c
+++ b/app/nginx-1.11.10/src/mail/ngx_mail.c
@@ -346,7 +346,7 @@ ngx_mail_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
 #endif
 
 #if (NGX_HAVE_FSTACK)
-            ls->belong_to_aeds = cscf->kernel_network_stack;
+            ls->belong_to_host = cscf->kernel_network_stack;
 #endif
 
             mport = ngx_palloc(cf->pool, sizeof(ngx_mail_port_t));

--- a/app/nginx-1.11.10/src/mail/ngx_mail.h
+++ b/app/nginx-1.11.10/src/mail/ngx_mail.h
@@ -112,6 +112,10 @@ typedef struct {
 
     ngx_str_t               server_name;
 
+#if (NGX_HAVE_FSTACK)
+    ngx_flag_t              kernel_network_stack;    /* kernel_network_stack */
+#endif
+
     u_char                 *file_name;
     ngx_uint_t              line;
 

--- a/app/nginx-1.11.10/src/mail/ngx_mail_core_module.c
+++ b/app/nginx-1.11.10/src/mail/ngx_mail_core_module.c
@@ -64,6 +64,17 @@ static ngx_command_t  ngx_mail_core_commands[] = {
       offsetof(ngx_mail_core_srv_conf_t, server_name),
       NULL },
 
+#if (NGX_HAVE_FSTACK)
+
+    { ngx_string("kernel_network_stack"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_core_srv_conf_t, kernel_network_stack),
+      NULL },
+
+#endif
+
     { ngx_string("error_log"),
       NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_1MORE,
       ngx_mail_core_error_log,
@@ -167,6 +178,9 @@ ngx_mail_core_create_srv_conf(ngx_conf_t *cf)
 
     cscf->file_name = cf->conf_file->file.name.data;
     cscf->line = cf->conf_file->line;
+#if (NGX_HAVE_FSTACK)
+    cscf->kernel_network_stack = NGX_CONF_UNSET;
+#endif
 
     return cscf;
 }
@@ -205,6 +219,12 @@ ngx_mail_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
     }
 
     ngx_conf_merge_ptr_value(conf->resolver, prev->resolver, NULL);
+
+#if (NGX_HAVE_FSTACK)
+    /* By default, we set up a server on fstack */
+    ngx_conf_merge_value(conf->kernel_network_stack,
+                              prev->kernel_network_stack, 0);
+#endif
 
     return NGX_CONF_OK;
 }

--- a/app/nginx-1.11.10/src/os/unix/ngx_channel.c
+++ b/app/nginx-1.11.10/src/os/unix/ngx_channel.c
@@ -223,7 +223,11 @@ ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd, ngx_int_t event,
 
     ev->handler = handler;
 
+#if (NGX_HAVE_FSTACK)
+    if (ngx_event_actions.add_conn && (ngx_event_flags & NGX_USE_EPOLL_EVENT) == 0) {
+#else
     if (ngx_add_conn && (ngx_event_flags & NGX_USE_EPOLL_EVENT) == 0) {
+#endif
         if (ngx_add_conn(c) == NGX_ERROR) {
             ngx_free_connection(c);
             return NGX_ERROR;

--- a/app/nginx-1.11.10/src/os/unix/ngx_process_cycle.c
+++ b/app/nginx-1.11.10/src/os/unix/ngx_process_cycle.c
@@ -737,9 +737,7 @@ ngx_master_process_exit(ngx_cycle_t *cycle)
         }
     }
 
-#if (!NGX_HAVE_FSTACK)
     ngx_close_listening_sockets(cycle);
-#endif
 
     /*
      * Copy ngx_cycle->log related data to the special static exit cycle,

--- a/app/nginx-1.11.10/src/stream/ngx_stream.c
+++ b/app/nginx-1.11.10/src/stream/ngx_stream.c
@@ -512,6 +512,10 @@ ngx_stream_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
             ls->reuseport = addr[i].opt.reuseport;
 #endif
 
+#if (NGX_HAVE_FSTACK)
+            ls->belong_to_aeds = cscf->kernel_network_stack;
+#endif
+
             stport = ngx_palloc(cf->pool, sizeof(ngx_stream_port_t));
             if (stport == NULL) {
                 return NGX_CONF_ERROR;

--- a/app/nginx-1.11.10/src/stream/ngx_stream.c
+++ b/app/nginx-1.11.10/src/stream/ngx_stream.c
@@ -513,7 +513,7 @@ ngx_stream_optimize_servers(ngx_conf_t *cf, ngx_array_t *ports)
 #endif
 
 #if (NGX_HAVE_FSTACK)
-            ls->belong_to_aeds = cscf->kernel_network_stack;
+            ls->belong_to_host = cscf->kernel_network_stack;
 #endif
 
             stport = ngx_palloc(cf->pool, sizeof(ngx_stream_port_t));

--- a/app/nginx-1.11.10/src/stream/ngx_stream.h
+++ b/app/nginx-1.11.10/src/stream/ngx_stream.h
@@ -185,6 +185,10 @@ typedef struct {
 
     ngx_msec_t                     proxy_protocol_timeout;
 
+#if (NGX_HAVE_FSTACK)
+    ngx_flag_t                     kernel_network_stack;    /* kernel_network_stack */
+#endif
+
     ngx_uint_t                     listen;  /* unsigned  listen:1; */
 } ngx_stream_core_srv_conf_t;
 

--- a/app/nginx-1.11.10/src/stream/ngx_stream_core_module.c
+++ b/app/nginx-1.11.10/src/stream/ngx_stream_core_module.c
@@ -56,6 +56,17 @@ static ngx_command_t  ngx_stream_core_commands[] = {
       0,
       NULL },
 
+#if (NGX_HAVE_FSTACK)
+
+    { ngx_string("kernel_network_stack"),
+      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      ngx_conf_set_flag_slot,
+      NGX_HTTP_SRV_CONF_OFFSET,
+      offsetof(ngx_http_core_srv_conf_t, kernel_network_stack),
+      NULL },
+
+#endif
+
     { ngx_string("error_log"),
       NGX_STREAM_MAIN_CONF|NGX_STREAM_SRV_CONF|NGX_CONF_1MORE,
       ngx_stream_core_error_log,
@@ -425,6 +436,9 @@ ngx_stream_core_create_srv_conf(ngx_conf_t *cf)
     cscf->tcp_nodelay = NGX_CONF_UNSET;
     cscf->preread_buffer_size = NGX_CONF_UNSET_SIZE;
     cscf->preread_timeout = NGX_CONF_UNSET_MSEC;
+#if (NGX_HAVE_FSTACK)
+    cscf->kernel_network_stack = NGX_CONF_UNSET;
+#endif
 
     return cscf;
 }
@@ -482,6 +496,12 @@ ngx_stream_core_merge_srv_conf(ngx_conf_t *cf, void *parent, void *child)
 
     ngx_conf_merge_msec_value(conf->preread_timeout,
                               prev->preread_timeout, 30000);
+
+#if (NGX_HAVE_FSTACK)
+    /* By default, we set up a server on fstack */
+    ngx_conf_merge_value(conf->kernel_network_stack,
+                              prev->kernel_network_stack, 0);
+#endif
 
     return NGX_CONF_OK;
 }

--- a/freebsd/kern/kern_descrip.c
+++ b/freebsd/kern/kern_descrip.c
@@ -4134,5 +4134,13 @@ ff_fdused_range(int max)
         fdalloc(td, 0, &result);
 }
 
+int
+ff_getmaxfd(void)
+{
+	struct thread *td = curthread;
+	return 	getmaxfd(td);
+	
+}
+
 #endif
 

--- a/lib/ff_api.h
+++ b/lib/ff_api.h
@@ -117,6 +117,7 @@ int ff_gettimeofday(struct timeval *tv, struct timezone *tz);
 /* Tests if fd is used by F-Stack */
 extern int ff_fdisused(int fd);
 
+extern int ff_getmaxfd(void);
 
 /* route api begin */
 enum FF_ROUTE_CTL {

--- a/lib/ff_api.symlist
+++ b/lib/ff_api.symlist
@@ -43,4 +43,5 @@ ff_route_ctl
 ff_rtioctl
 ff_gettimeofday
 ff_fdisused
+ff_getmaxfd
 ff_ngctl

--- a/lib/include/sys/filedesc.h
+++ b/lib/include/sys/filedesc.h
@@ -32,5 +32,6 @@
 
 void ff_fdused_range(int max);
 int ff_fdisused(int fd);
+int ff_getmaxfd(void);
 
 #endif    /* _FSTACK_SYS_FILEDESC_H_ */


### PR DESCRIPTION
So we can do what fstack can't do,  e.g. unix socket, ipc (with APP on kernel network stack), packet from kernel network stack.
1. Add a new directive kernel_network_stack :
    Syntax: 	kernel_network_stack on | off;
    Default: 	kernel_network_stack off;
   Context: 	http, server
  This directive is available only when NGX_HAVE_FSTACK is defined.
  Determines whether server should run on kernel network stack or fstack.
2. Use a simpler and  more effective solution to discriminate fstack fd(file descriptor, only socket for now) from kernel fd.

