### PR TITLE
Nginx : Get rid of "ff_host" thread

### DIFF
--- a/app/nginx-1.11.10/src/core/nginx.c
+++ b/app/nginx-1.11.10/src/core/nginx.c
@@ -156,6 +156,13 @@ static ngx_command_t  ngx_core_commands[] = {
       0,
       offsetof(ngx_core_conf_t, fstack_conf),
       NULL },
+
+    { ngx_string("schedule_timeout"),
+      NGX_MAIN_CONF|NGX_DIRECT_CONF|NGX_CONF_TAKE1,
+      ngx_conf_set_msec_slot,
+      0,
+      offsetof(ngx_core_conf_t, schedule_timeout),
+      NULL },
 #endif
 
       ngx_null_command
@@ -1037,6 +1044,10 @@ ngx_core_module_create_conf(ngx_cycle_t *cycle)
     ccf->user = (ngx_uid_t) NGX_CONF_UNSET_UINT;
     ccf->group = (ngx_gid_t) NGX_CONF_UNSET_UINT;
 
+#if (NGX_HAVE_FSTACK)
+    ccf->schedule_timeout = NGX_CONF_UNSET_MSEC;
+#endif
+
     if (ngx_array_init(&ccf->env, cycle->pool, 1, sizeof(ngx_str_t))
         != NGX_OK)
     {
@@ -1058,6 +1069,10 @@ ngx_core_module_init_conf(ngx_cycle_t *cycle, void *conf)
 
     ngx_conf_init_value(ccf->worker_processes, 1);
     ngx_conf_init_value(ccf->debug_points, 0);
+
+#if (NGX_HAVE_FSTACK)
+    ngx_conf_init_msec_value(ccf->schedule_timeout, 30);
+#endif
 
 #if (NGX_HAVE_CPU_AFFINITY)
 

--- a/app/nginx-1.11.10/src/core/ngx_connection.c
+++ b/app/nginx-1.11.10/src/core/ngx_connection.c
@@ -1076,9 +1076,6 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
     ngx_uint_t         instance;
     ngx_event_t       *rev, *wev;
     ngx_connection_t  *c;
-#if (NGX_HAVE_FSTACK)
-    ngx_atomic_uint_t  success;
-#endif
 
     /* disable warning: Win32 SOCKET is u_int while UNIX socket is int */
 
@@ -1089,35 +1086,7 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
                       s, ngx_cycle->files_n);
         return NULL;
     }
-#if (NGX_HAVE_FSTACK)
-#ifndef unlikely
-#define unlikely(x)  __builtin_expect((x),0)
-#endif
-    /* move ngx_cycle->free_connections atomically */
-	do {
-		/* Restore n as it may change every loop */
-		c = ngx_cycle->free_connections;
 
-        if (c == NULL) {
-            ngx_drain_connections((ngx_cycle_t *) ngx_cycle);
-            c = ngx_cycle->free_connections;
-        }
-
-        if (c == NULL) {
-            ngx_log_error(NGX_LOG_ALERT, log, 0,
-                        "%ui worker_connections are not enough",
-                        ngx_cycle->connection_n);
-
-            return NULL;
-        }
-
-		success = ngx_atomic_cmp_set(&ngx_cycle->free_connections, c,
-					      c->data);
-
-	} while (unlikely(success == 0));
-
-	ngx_memory_barrier();
-#else
     c = ngx_cycle->free_connections;
 
     if (c == NULL) {
@@ -1134,7 +1103,6 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
     }
 
     ngx_cycle->free_connections = c->data;
-#endif
     ngx_cycle->free_connection_n--;
 
     if (ngx_cycle->files && ngx_cycle->files[s] == NULL) {
@@ -1178,25 +1146,8 @@ ngx_get_connection(ngx_socket_t s, ngx_log_t *log)
 void
 ngx_free_connection(ngx_connection_t *c)
 {
-#if (NGX_HAVE_FSTACK)
-    ngx_atomic_uint_t  success;
-
-    /* move ngx_cycle->free_connections atomically */
-	do {
-		/* Restore n as it may change every loop */
-		c->data = ngx_cycle->free_connections;
-
-		success = ngx_atomic_cmp_set(&ngx_cycle->free_connections, c->data,
-					      c);
-
-	} while (unlikely(success == 0));
-
-	ngx_memory_barrier();
-
-#else
+    c->data = ngx_cycle->free_connections;
     ngx_cycle->free_connections = c;
-
-#endif
     ngx_cycle->free_connection_n++;
 
     if (ngx_cycle->files && ngx_cycle->files[c->fd] == c) {

--- a/app/nginx-1.11.10/src/core/ngx_cycle.h
+++ b/app/nginx-1.11.10/src/core/ngx_cycle.h
@@ -116,6 +116,7 @@ typedef struct {
 
 #if (NGX_HAVE_FSTACK)
     ngx_str_t                 fstack_conf;
+    ngx_msec_t                schedule_timeout;
 #endif
 } ngx_core_conf_t;
 

--- a/app/nginx-1.11.10/src/event/ngx_event.c
+++ b/app/nginx-1.11.10/src/event/ngx_event.c
@@ -204,7 +204,6 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
     ngx_uint_t  flags;
     ngx_msec_t  timer, delta;
 #if (NGX_HAVE_FSTACK)
-    static ngx_uint_t tick;
     static ngx_msec_t initial; //msec
 #endif
 
@@ -255,14 +254,12 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
 
 #if (NGX_HAVE_FSTACK)
     /* handle message from kernel (PS: signals from master) in case of network inactivity */
-    if (ngx_current_msec - initial >= ngx_schedule_timeout || tick >= ngx_schedule_timeout) {
+    if (ngx_current_msec - initial >= ngx_schedule_timeout) {
         (void) ngx_ff_process_host_events(cycle, 0, flags);
 
         /* Update timer*/
         initial = ngx_current_msec;
-        tick = 0;
     }
-    tick++;
 #endif
 
     delta = ngx_current_msec - delta;

--- a/app/nginx-1.11.10/src/event/ngx_event.c
+++ b/app/nginx-1.11.10/src/event/ngx_event.c
@@ -34,6 +34,10 @@ static char *ngx_event_debug_connection(ngx_conf_t *cf, ngx_command_t *cmd,
 static void *ngx_event_core_create_conf(ngx_cycle_t *cycle);
 static char *ngx_event_core_init_conf(ngx_cycle_t *cycle, void *conf);
 
+#if (NGX_HAVE_FSTACK)
+extern ngx_int_t ngx_ff_epoll_process_events(ngx_cycle_t *cycle,
+    ngx_msec_t timer, ngx_uint_t flags);
+#endif
 
 static ngx_uint_t     ngx_timer_resolution;
 sig_atomic_t          ngx_event_timer_alarm;
@@ -55,6 +59,10 @@ ngx_uint_t            ngx_accept_events;
 ngx_uint_t            ngx_accept_mutex_held;
 ngx_msec_t            ngx_accept_mutex_delay;
 ngx_int_t             ngx_accept_disabled;
+
+#if (NGX_HAVE_FSTACK)
+static ngx_msec_t     ngx_schedule_timeout;
+#endif
 
 
 #if (NGX_STAT_STUB)
@@ -195,6 +203,10 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
 {
     ngx_uint_t  flags;
     ngx_msec_t  timer, delta;
+#if (NGX_HAVE_FSTACK)
+    static ngx_uint_t tick;
+    static ngx_msec_t initial; //msec
+#endif
 
     if (ngx_timer_resolution) {
         timer = NGX_TIMER_INFINITE;
@@ -239,7 +251,19 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
 
     delta = ngx_current_msec;
 
-    (void) ngx_process_events(cycle, timer, flags);
+    //(void) ngx_process_events(cycle, timer, flags);
+
+#if (NGX_HAVE_FSTACK)
+    /* handle message from kernel (PS: signals from master) in case of network inactivity */
+    if (ngx_current_msec - initial >= ngx_schedule_timeout || tick >= ngx_schedule_timeout) {
+        (void) ngx_ff_process_host_events(cycle, 0, flags);
+
+        /* Update timer*/
+        initial = ngx_current_msec;
+        tick = 0;
+    }
+    tick++;
+#endif
 
     delta = ngx_current_msec - delta;
 
@@ -546,6 +570,10 @@ ngx_event_module_init(ngx_cycle_t *cycle)
 
 #endif
 
+#if (NGX_HAVE_FSTACK)
+    ngx_schedule_timeout = ccf->schedule_timeout;
+#endif
+
     return NGX_OK;
 }
 
@@ -606,11 +634,6 @@ ngx_event_process_init(ngx_cycle_t *cycle)
 
     ngx_queue_init(&ngx_posted_accept_events);
     ngx_queue_init(&ngx_posted_events);
-
-#if (NGX_HAVE_FSTACK)
-    ngx_queue_init(&ngx_posted_accept_events_of_host);
-    ngx_queue_init(&ngx_posted_events_of_host);
-#endif
 
     if (ngx_event_timer_init(cycle->log) == NGX_ERROR) {
         return NGX_ERROR;

--- a/app/nginx-1.11.10/src/event/ngx_event.c
+++ b/app/nginx-1.11.10/src/event/ngx_event.c
@@ -251,7 +251,7 @@ ngx_process_events_and_timers(ngx_cycle_t *cycle)
 
     delta = ngx_current_msec;
 
-    //(void) ngx_process_events(cycle, timer, flags);
+    (void) ngx_process_events(cycle, timer, flags);
 
 #if (NGX_HAVE_FSTACK)
     /* handle message from kernel (PS: signals from master) in case of network inactivity */

--- a/app/nginx-1.11.10/src/event/ngx_event.h
+++ b/app/nginx-1.11.10/src/event/ngx_event.h
@@ -453,6 +453,8 @@ static inline ngx_int_t ngx_process_events(
     return ngx_event_actions.process_events(cycle, timer, flags);
 }
 
+#define ngx_ff_process_host_events   ngx_ff_host_event_actions.process_events
+
 #else
 
 #define ngx_process_events   ngx_event_actions.process_events

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.c
@@ -13,11 +13,6 @@
 ngx_queue_t  ngx_posted_accept_events;
 ngx_queue_t  ngx_posted_events;
 
-#if (NGX_HAVE_FSTACK)
-ngx_queue_t  ngx_posted_accept_events_of_host;
-ngx_queue_t  ngx_posted_events_of_host;
-#endif
-
 
 void
 ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted)

--- a/app/nginx-1.11.10/src/event/ngx_event_posted.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_posted.h
@@ -14,34 +14,6 @@
 #include <ngx_event.h>
 
 
-#if (NGX_HAVE_FSTACK)
-#define ngx_post_event(ev, q)                                                 \
-                                                                              \
-    if (!(ev)->posted) {                                                      \
-        (ev)->posted = 1;                                                     \
-        if (1 == (ev)->belong_to_host) {                                      \
-            if (q == &ngx_posted_events) {                                    \
-                ngx_queue_insert_tail(                                        \
-                    &ngx_posted_events_of_host, &(ev)->queue);                \
-            } else if (q == &ngx_posted_accept_events) {                      \
-                ngx_queue_insert_tail(                                        \
-                    &ngx_posted_accept_events_of_host, &(ev)->queue);         \
-            } else {                                                          \
-                ngx_log_error(NGX_LOG_EMERG, (ev)->log, 0,                    \
-                          "ngx_post_event: unkowned posted queue");           \
-                exit(1);                                                      \
-            }                                                                 \
-        } else {                                                              \
-            ngx_queue_insert_tail(q, &(ev)->queue);                           \
-        }                                                                     \
-                                                                              \
-        ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0, "post event %p", ev);\
-                                                                              \
-    } else  {                                                                 \
-        ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0,                      \
-                       "update posted event %p", ev);                         \
-    }
-#else
 #define ngx_post_event(ev, q)                                                 \
                                                                               \
     if (!(ev)->posted) {                                                      \
@@ -54,7 +26,6 @@
         ngx_log_debug1(NGX_LOG_DEBUG_CORE, (ev)->log, 0,                      \
                        "update posted event %p", ev);                         \
     }
-#endif
 
 
 #define ngx_delete_posted_event(ev)                                           \
@@ -73,9 +44,5 @@ void ngx_event_process_posted(ngx_cycle_t *cycle, ngx_queue_t *posted);
 extern ngx_queue_t  ngx_posted_accept_events;
 extern ngx_queue_t  ngx_posted_events;
 
-#if (NGX_HAVE_FSTACK)
-extern ngx_queue_t  ngx_posted_accept_events_of_host;
-extern ngx_queue_t  ngx_posted_events_of_host;
-#endif
 
 #endif /* _NGX_EVENT_POSTED_H_INCLUDED_ */

--- a/app/nginx-1.11.10/src/event/ngx_event_timer.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_timer.h
@@ -27,9 +27,6 @@ void ngx_event_cancel_timers(void);
 
 extern ngx_rbtree_t  ngx_event_timer_rbtree;
 
-#if (NGX_HAVE_FSTACK)
-extern ngx_rbtree_t  ngx_event_timer_rbtree_of_host;
-#endif
 
 static ngx_inline void
 ngx_event_del_timer(ngx_event_t *ev)
@@ -38,19 +35,7 @@ ngx_event_del_timer(ngx_event_t *ev)
                    "event timer del: %d: %M",
                     ngx_event_ident(ev->data), ev->timer.key);
 
-#if (NGX_HAVE_FSTACK)
-
-    if(ev->belong_to_host){
-        ngx_rbtree_delete(&ngx_event_timer_rbtree_of_host, &ev->timer);
-    } else {
-        ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
-    }
-
-#else
-
     ngx_rbtree_delete(&ngx_event_timer_rbtree, &ev->timer);
-
-#endif
 
 #if (NGX_DEBUG)
     ev->timer.left = NULL;
@@ -96,19 +81,7 @@ ngx_event_add_timer(ngx_event_t *ev, ngx_msec_t timer)
                    "event timer add: %d: %M:%M",
                     ngx_event_ident(ev->data), timer, ev->timer.key);
 
-#if (NGX_HAVE_FSTACK)
-
-    if(ev->belong_to_host){
-        ngx_rbtree_insert(&ngx_event_timer_rbtree_of_host, &ev->timer);
-    } else {
-        ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);
-    }
-
-#else
-
     ngx_rbtree_insert(&ngx_event_timer_rbtree, &ev->timer);
-
-#endif
 
     ev->timer_set = 1;
 }

--- a/app/nginx-1.11.10/src/os/unix/ngx_channel.c
+++ b/app/nginx-1.11.10/src/os/unix/ngx_channel.c
@@ -213,6 +213,10 @@ ngx_add_channel_event(ngx_cycle_t *cycle, ngx_fd_t fd, ngx_int_t event,
     rev = c->read;
     wev = c->write;
 
+#if (NGX_HAVE_FSTACK)
+    rev->belong_to_host = wev->belong_to_host = 1;
+#endif
+
     rev->log = cycle->log;
     wev->log = cycle->log;
 

--- a/app/nginx-1.11.10/src/os/unix/ngx_process_cycle.c
+++ b/app/nginx-1.11.10/src/os/unix/ngx_process_cycle.c
@@ -22,12 +22,7 @@ static void ngx_master_process_exit(ngx_cycle_t *cycle);
 static void ngx_worker_process_cycle(ngx_cycle_t *cycle, void *data);
 static void ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker);
 static void ngx_worker_process_exit(ngx_cycle_t *cycle);
-#if (NGX_HAVE_FSTACK)
-extern ngx_int_t ngx_ff_start_worker_channel(ngx_cycle_t *cycle,
-    ngx_fd_t fd, ngx_int_t event);
-#else
 static void ngx_channel_handler(ngx_event_t *ev);
-#endif
 static void ngx_cache_manager_process_cycle(ngx_cycle_t *cycle, void *data);
 static void ngx_cache_manager_process_handler(ngx_event_t *ev);
 static void ngx_cache_loader_process_handler(ngx_event_t *ev);
@@ -1057,12 +1052,8 @@ ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
     ngx_last_process = 0;
 #endif
 
-#if (NGX_HAVE_FSTACK)
-    if (ngx_ff_start_worker_channel(cycle, ngx_channel, NGX_READ_EVENT)
-#else
     if (ngx_add_channel_event(cycle, ngx_channel, NGX_READ_EVENT,
                               ngx_channel_handler)
-#endif
         == NGX_ERROR)
     {
         /* fatal */
@@ -1137,7 +1128,6 @@ ngx_worker_process_exit(ngx_cycle_t *cycle)
     exit(0);
 }
 
-#if (!NGX_HAVE_FSTACK)
 static void
 ngx_channel_handler(ngx_event_t *ev)
 {
@@ -1224,7 +1214,6 @@ ngx_channel_handler(ngx_event_t *ev)
         }
     }
 }
-#endif
 
 static void
 ngx_cache_manager_process_cycle(ngx_cycle_t *cycle, void *data)


### PR DESCRIPTION
Get rid of "ff_host" thread dealing with the kernel (including channel). So there will be one thread for each nginx worker. And use directive "schedule_timeout" to adjust poll frequency of kernel.
This is a better way to ```support kernel network stack #117```