### PR TITLE
Nginx :  ngx_configure_listening_sockets and hijack `recvmsg`

### DIFF
--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
@@ -109,6 +109,7 @@ static ssize_t (*real_send)(int, const void *, size_t, int);
 static ssize_t (*real_sendto)(int, const void *, size_t, int,
     const struct sockaddr*, socklen_t);
 static ssize_t (*real_sendmsg)(int, const struct msghdr*, int);
+static ssize_t (*real_recvmsg)(int, struct msghdr *, int);
 static ssize_t (*real_writev)(int, const struct iovec *, int);
 static ssize_t (*real_readv)(int, const struct iovec *, int);
 
@@ -290,6 +291,16 @@ sendmsg(int sockfd, const struct msghdr *msg, int flags)
     }
 
     return SYSCALL(sendmsg)(sockfd, msg, flags);
+}
+
+ssize_t recvmsg(int sockfd, struct msghdr *msg, int flags)
+{
+    if(is_fstack_fd(sockfd)){
+        sockfd = restore_fstack_fd(sockfd);
+        return ff_recvmsg(sockfd, msg, flags);
+    }
+
+    return SYSCALL(recvmsg)(sockfd, msg, flags);
 }
 
 ssize_t

--- a/app/nginx-1.11.10/src/os/unix/ngx_process_cycle.c
+++ b/app/nginx-1.11.10/src/os/unix/ngx_process_cycle.c
@@ -1002,6 +1002,10 @@ ngx_worker_process_init(ngx_cycle_t *cycle, ngx_int_t worker)
                           "ngx_open_listening_sockets failed");
             exit(2);
         }
+
+        if (!ngx_test_config) {
+            ngx_configure_listening_sockets(cycle);
+        }
     }
 #endif
 


### PR DESCRIPTION
1. Nginx based on fstack delays setting up server on fstack until ngx_worker_process_init. ngx_configure_listening_sockets should as well.
2. FStack does not support IP_PKTINFO

Fix #157 .