### PR TITLE
Nginx : directive proxy_kernel_network_stack

### DIFF
--- a/app/nginx-1.11.10/auto/modules
+++ b/app/nginx-1.11.10/auto/modules
@@ -58,6 +58,7 @@ fi
 if [ $USE_FSTACK = YES ]; then
     have=NGX_HAVE_FSTACK . auto/have
     have=NGX_HAVE_FSTACK . auto/have_headers
+    have=SOCK_FSTACK value=0x1000 . auto/define
     CORE_SRCS="$CORE_SRCS $KQUEUE_SRCS"
     EVENT_MODULES="$EVENT_MODULES $KQUEUE_MODULE"
 fi

--- a/app/nginx-1.11.10/src/core/ngx_connection.c
+++ b/app/nginx-1.11.10/src/core/ngx_connection.c
@@ -15,7 +15,7 @@ extern int fstack_territory(int domain, int type, int protocol);
 extern int is_fstack_fd(int sockfd);
 
 static ngx_inline int
-ngx_ff_skip_listening_socket(ngx_cycle_t *cycle, const ngx_listening_t  *ls)
+ngx_ff_skip_listening_socket(ngx_cycle_t *cycle, ngx_listening_t *ls)
 {
     if (ngx_process <= NGX_PROCESS_MASTER) {
 
@@ -36,6 +36,8 @@ ngx_ff_skip_listening_socket(ngx_cycle_t *cycle, const ngx_listening_t  *ls)
         if (!fstack_territory(ls->sockaddr->sa_family, ls->type, 0)) {
             return 1;
         }
+
+        ls->type |= SOCK_FSTACK;
     } else {
         ngx_log_error(NGX_LOG_ALERT, cycle->log, 0,
                             "unexpected process type: %d, ignored",

--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
@@ -210,8 +210,8 @@ int
 fstack_territory(int domain, int type, int protocol)
 {
     /* Remove creation flags */
-	type &= ~SOCK_CLOEXEC;
-	type &= ~SOCK_NONBLOCK;
+    type &= ~SOCK_CLOEXEC;
+    type &= ~SOCK_NONBLOCK;
     type &= ~SOCK_FSTACK;
 
     if ((AF_INET != domain) || (SOCK_STREAM != type && SOCK_DGRAM != type)) {
@@ -233,9 +233,9 @@ socket(int domain, int type, int protocol)
         return SYSCALL(socket)(domain, type, protocol);
     }
 
-	if (unlikely((type & SOCK_FSTACK) == 0)) {
-		return SYSCALL(socket)(domain, type, protocol);
-	}
+    if (unlikely((type & SOCK_FSTACK) == 0)) {
+        return SYSCALL(socket)(domain, type, protocol);
+    }
 
     type &= ~SOCK_FSTACK;
     sock = ff_socket(domain, type, protocol);
@@ -287,7 +287,7 @@ sendto(int sockfd, const void *buf, size_t len, int flags,
     if(is_fstack_fd(sockfd)){
         sockfd = restore_fstack_fd(sockfd);
         return ff_sendto(sockfd, buf, len, flags,
-	        (struct linux_sockaddr *)dest_addr, addrlen);
+            (struct linux_sockaddr *)dest_addr, addrlen);
     }
 
     return SYSCALL(sendto)(sockfd, buf, len, flags, dest_addr, addrlen);

--- a/app/nginx-1.11.10/src/event/ngx_event_connect.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.c
@@ -39,22 +39,17 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
     type = (pc->type ? pc->type : SOCK_STREAM);
 
 #if (NGX_HAVE_FSTACK)
-    /* 
-     We need to explicitly call the needed socket() function
-         to create socket!
+    /*
+     We use a creation flags created by fstack's adaptable layer to 
+      to explicitly call the needed socket() function.
     */
-    static int (*real_socket)(int, int, int);
-    if (pc->belong_to_host) {
-        if (!real_socket) {
-            real_socket = dlsym(RTLD_NEXT, "socket");
-        }
-        s = real_socket(pc->sockaddr->sa_family, type, 0);
-    } else {
-        s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+    if (!pc->belong_to_host) {
+        type |= SOCK_FSTACK;
     }
-#else
-    s = ngx_socket(pc->sockaddr->sa_family, type, 0);
 #endif
+
+    s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0, "%s socket %d",
                    (type == SOCK_STREAM) ? "stream" : "dgram", s);

--- a/app/nginx-1.11.10/src/event/ngx_event_connect.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.c
@@ -38,7 +38,23 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
 
     type = (pc->type ? pc->type : SOCK_STREAM);
 
+#if (NGX_HAVE_FSTACK)
+    /* 
+     We need to explicitly call the needed socket() function
+         to create socket!
+    */
+    static int (*real_socket)(int, int, int);
+    if (pc->belong_to_host) {
+        if (!real_socket) {
+            real_socket = dlsym(RTLD_NEXT, "socket");
+        }
+        s = real_socket(pc->sockaddr->sa_family, type, 0);
+    } else {
+        s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+    }
+#else
     s = ngx_socket(pc->sockaddr->sa_family, type, 0);
+#endif
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0, "%s socket %d",
                    (type == SOCK_STREAM) ? "stream" : "dgram", s);

--- a/app/nginx-1.11.10/src/event/ngx_event_connect.h
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.h
@@ -66,6 +66,10 @@ struct ngx_peer_connection_s {
                                      /* ngx_connection_log_error_e */
     unsigned                         log_error:2;
 
+#if (NGX_HAVE_FSTACK)
+    unsigned                         belong_to_host:1;
+#endif
+
     NGX_COMPAT_BEGIN(2)
     NGX_COMPAT_END
 };

--- a/app/nginx-1.11.10/src/http/ngx_http_core_module.c
+++ b/app/nginx-1.11.10/src/http/ngx_http_core_module.c
@@ -3455,7 +3455,9 @@ ngx_http_core_create_srv_conf(ngx_conf_t *cf)
     cscf->ignore_invalid_headers = NGX_CONF_UNSET;
     cscf->merge_slashes = NGX_CONF_UNSET;
     cscf->underscores_in_headers = NGX_CONF_UNSET;
+#if (NGX_HAVE_FSTACK)
     cscf->kernel_network_stack = NGX_CONF_UNSET;
+#endif
 
     return cscf;
 }

--- a/app/nginx-1.11.10/src/mail/ngx_mail_core_module.c
+++ b/app/nginx-1.11.10/src/mail/ngx_mail_core_module.c
@@ -67,10 +67,10 @@ static ngx_command_t  ngx_mail_core_commands[] = {
 #if (NGX_HAVE_FSTACK)
 
     { ngx_string("kernel_network_stack"),
-      NGX_HTTP_MAIN_CONF|NGX_HTTP_SRV_CONF|NGX_CONF_FLAG,
+      NGX_MAIL_MAIN_CONF|NGX_MAIL_SRV_CONF|NGX_CONF_FLAG,
       ngx_conf_set_flag_slot,
-      NGX_HTTP_SRV_CONF_OFFSET,
-      offsetof(ngx_http_core_srv_conf_t, kernel_network_stack),
+      NGX_MAIL_SRV_CONF_OFFSET,
+      offsetof(ngx_mail_core_srv_conf_t, kernel_network_stack),
       NULL },
 
 #endif

--- a/doc/F-Stack_Nginx_APP_Guide.md
+++ b/doc/F-Stack_Nginx_APP_Guide.md
@@ -63,7 +63,7 @@ All the directives below are available only when ```NGX_HAVE_FSTACK``` is define
 
 ```
     Syntax: schedule_timeout time;
-    Default: schedule_timeout 30m;
+    Default: schedule_timeout 30ms;
     Context: http, server
 
     Sets a time interval for polling kernel_network_stack. The default value is 30 msec.

--- a/doc/F-Stack_Nginx_APP_Guide.md
+++ b/doc/F-Stack_Nginx_APP_Guide.md
@@ -42,21 +42,37 @@ first one to start |                    |     |                   |    |        
 
 - a major addition to the worker process is fstack-handling：ff_init();ff_run(worker_process_cycle); worker_process_cycle(handle channel/host/fstack event).
 
-- a new directive `kernel_network_stack` :
+## What's Different?
+### New directives:
+All the directives below are available only when ```NGX_HAVE_FSTACK``` is defined.
 ```
     Syntax: kernel_network_stack on | off;
     Default: kernel_network_stack off;
     Context: http, server
-    This directive is available only when ```NGX_HAVE_FSTACK``` is defined.
+
     Determines whether server should run on kernel network stack or fstack.
 ```
 
-Note that:
+```
+    Syntax: proxy_kernel_network_stack on | off;
+    Default: kernel_network_stack off;
+    Context: http, stream, mail, server
 
-- the `reload` is not graceful, service will still be unavailable during the process of reloading.
+    Determines whether proxy should go through kernel network stack or fstack.
+```
 
-- necessary modifies in nginx.conf:
+```
+    Syntax: schedule_timeout time;
+    Default: schedule_timeout 30m;
+    Context: http, server
 
+    Sets a time interval for polling kernel_network_stack. The default value is 30 msec.
+```
+
+### Command-line `reload`
+the `reload` is not graceful, service will still be unavailable during the process of reloading.
+
+### Necessary modifies in nginx.conf:
 ```
     user  root; # root account is necessary.
     fstack_conf f-stack.conf;  # path of f-stack configuration file, default: $NGX_PREFIX/conf/f-stack.conf.


### PR DESCRIPTION
1. Add a new directive ```proxy_kernel_network_stack``` :
```
Syntax: 	proxy_kernel_network_stack on | off;
Default: 	proxy_kernel_network_stack off;
Context: 	http, stream, mail, server
```
This directive is available only when ```NGX_HAVE_FF_STACK``` is defined.
Determines whether proxy should go throught kernel network stack or fstack.
2. Update F-Stack_Nginx_APP_Guide.md