### PR TITLE
Nginx: bugfix, shouldnot pollute `socket type`

### DIFF
--- a/app/nginx-1.11.10/src/event/ngx_event_connect.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.c
@@ -44,12 +44,13 @@ ngx_event_connect_peer(ngx_peer_connection_t *pc)
       to explicitly call the needed socket() function.
     */
     if (!pc->belong_to_host) {
-        type |= SOCK_FSTACK;
+        s = ngx_socket(pc->sockaddr->sa_family, type | SOCK_FSTACK, 0);
+    } else {
+        s = ngx_socket(pc->sockaddr->sa_family, type, 0);
     }
-#endif
-
+#else
     s = ngx_socket(pc->sockaddr->sa_family, type, 0);
-
+#endif
 
     ngx_log_debug2(NGX_LOG_DEBUG_EVENT, pc->log, 0, "%s socket %d",
                    (type == SOCK_STREAM) ? "stream" : "dgram", s);


### PR DESCRIPTION
We use a creation flags created by fstack's adaptable layer to explicitly call the needed socket() function. But we shouldnot pollute `socket type`.