### PR TITLE
Nginx: fixbug, hijack `__recv_chk`.

### DIFF
--- a/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
+++ b/app/nginx-1.11.10/src/event/modules/ngx_ff_module.c
@@ -325,6 +325,16 @@ recv(int sockfd, void *buf, size_t len, int flags)
     return SYSCALL(recv)(sockfd, buf, len, flags);
 }
 
+ssize_t
+__recv_chk (int fd, void *buf, size_t n, size_t buflen, int flags)
+{
+/*
+  if (n > buflen)
+    __chk_fail ();
+*/
+  return recv (fd, buf, n, flags);
+}
+
 int
 listen(int sockfd, int backlog)
 {


### PR DESCRIPTION
Nginx maybe call `__recv_chk` with https because of _FORTIFY_SOURCE (-O1 and higher).
Refer to #179.
See _FORTIFY_SOURCE (since glibc 2.3.4)