### PR TITLE
Update F-Stack_Nginx_APP_Guide.md

### DIFF
--- a/doc/F-Stack_Nginx_APP_Guide.md
+++ b/doc/F-Stack_Nginx_APP_Guide.md
@@ -64,7 +64,7 @@ All the directives below are available only when ```NGX_HAVE_FSTACK``` is define
 ```
     Syntax: schedule_timeout time;
     Default: schedule_timeout 30ms;
-    Context: http, server
+    Context: main
 
     Sets a time interval for polling kernel_network_stack. The default value is 30 msec.
 ```


### PR DESCRIPTION
The context of `schedule_timeout` is `main`.