### PR TITLE
reset cpu affinity when new process forked.

### DIFF
--- a/app/redis-3.2.8/src/aof.c
+++ b/app/redis-3.2.8/src/aof.c
@@ -1272,6 +1272,7 @@ int rewriteAppendOnlyFileBackground(void) {
 
         /* Child */
         closeListeningSockets(0);
+        resetCpuAffinity("aof-rewrite");
         redisSetProcTitle("redis-aof-rewrite");
         snprintf(tmpfile,256,"temp-rewriteaof-bg-%d.aof", (int) getpid());
         if (rewriteAppendOnlyFile(tmpfile) == C_OK) {

--- a/app/redis-3.2.8/src/rdb.c
+++ b/app/redis-3.2.8/src/rdb.c
@@ -930,6 +930,7 @@ int rdbSaveBackground(char *filename) {
 
         /* Child */
         closeListeningSockets(0);
+        resetCpuAffinity("rdb-bgsave");
         redisSetProcTitle("redis-rdb-bgsave");
         retval = rdbSave(filename);
         if (retval == C_OK) {
@@ -1631,6 +1632,7 @@ int rdbSaveToSlavesSockets(void) {
         zfree(fds);
 
         closeListeningSockets(0);
+        resetCpuAffinity("rdb2slave");
         redisSetProcTitle("redis-rdb-to-slaves");
 
         retval = rdbSaveRioWithEOFMark(&slave_sockets,NULL);

--- a/app/redis-3.2.8/src/scripting.c
+++ b/app/redis-3.2.8/src/scripting.c
@@ -1611,6 +1611,7 @@ int ldbStartSession(client *c) {
              * to the clients. */
             serverLog(LL_WARNING,"Redis forked for debugging eval");
             closeListeningSockets(0);
+            resetCpuAffinity("redis-dbg");
         } else {
             /* Parent */
             listAddNodeTail(ldb.children,(void*)(unsigned long)cp);

--- a/app/redis-3.2.8/src/sentinel.c
+++ b/app/redis-3.2.8/src/sentinel.c
@@ -763,6 +763,7 @@ void sentinelRunPendingScripts(void) {
             sj->pid = 0;
         } else if (pid == 0) {
             /* Child */
+            resetCpuAffinity(NULL);
             execve(sj->argv[0],sj->argv,environ);
             /* If we are here an error occurred. */
             _exit(2); /* Don't retry execution. */

--- a/app/redis-3.2.8/src/server.c
+++ b/app/redis-3.2.8/src/server.c
@@ -2565,7 +2565,7 @@ void resetCpuAffinity(const char* name)
 	int j = 0, s = 0;
 	cput_set_t cpuset_frm, cpuset_to;
 	pthread_t thread;
-#ifdef __linux__
+#ifdef HAVE_FF_KQUEUE
 	thread = pthread_self();
 	CPU_ZERO(&cpuset_frm);
 	CPU_ZERO(&cpuset_to);

--- a/app/redis-3.2.8/src/server.h
+++ b/app/redis-3.2.8/src/server.h
@@ -42,6 +42,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <inttypes.h>
+#define _GNU_SOURCE
 #include <pthread.h>
 #include <syslog.h>
 #include <netinet/in.h>
@@ -1332,6 +1333,8 @@ void populateCommandTable(void);
 void resetCommandTableStats(void);
 void adjustOpenFilesLimit(void);
 void closeListeningSockets(int unlink_unix_socket);
+void resetCpuAffinity(const char* name);
+
 void updateCachedTime(void);
 void resetServerStats(void);
 unsigned int getLRUClock(void);


### PR DESCRIPTION
New forked process should not compete same core with redis server. Fstack redis-server should own one specific core.