### PR TITLE
Update freebsd/netinet/in_pcb.c

### DIFF
--- a/freebsd/netinet/in_pcb.c
+++ b/freebsd/netinet/in_pcb.c
@@ -1114,6 +1114,7 @@ in_pcbconnect_setup(struct inpcb *inp, struct sockaddr *nam,
 			return (error);
 	}
 #else
+if (lport == 0)
 {
     struct ifaddr *ifa;
     struct ifnet *ifp;


### PR DESCRIPTION
BSD's socket can bind the address not belong to local ports, this works well when using as transparent proxy. If fstack check the ip and port whenever new connect, tranparent proxy is not supported.
When using specified local port, it is app's responsibility to make 5-tuple rss hash good.