### PR TITLE
fstack only support IP_BINDANY,  not support IP_TRANSPARENT.

### DIFF
--- a/app/nginx-1.11.10/src/event/ngx_event_connect.c
+++ b/app/nginx-1.11.10/src/event/ngx_event_connect.c
@@ -360,25 +360,28 @@ ngx_event_connect_set_transparent(ngx_peer_connection_t *pc, ngx_socket_t s)
 
     case AF_INET:
 
-#if defined(IP_TRANSPARENT)
-
-        if (setsockopt(s, IPPROTO_IP, IP_TRANSPARENT,
-                       (const void *) &value, sizeof(int)) == -1)
+#if defined(NGX_HAVE_FSTACK)
+	/****
+	FreeBSD define IP_BINDANY in freebsd/netinet/in.h
+	Fstack should only support IP_BINDANY.
+	****/
+	#define IP_BINDANY	24	
+	if (setsockopt(s, IPPROTO_IP, IP_BINDANY,
+                (const void *) &value, sizeof(int)) == -1)
         {
             ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
-                          "setsockopt(IP_TRANSPARENT) failed");
+                   "setsockopt(IP_BINDANY) failed");
             return NGX_ERROR;
         }
-
-#elif defined(IP_BINDANY)
-
-        if (setsockopt(s, IPPROTO_IP, IP_BINDANY,
-                       (const void *) &value, sizeof(int)) == -1)
-        {
-            ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
-                          "setsockopt(IP_BINDANY) failed");
-            return NGX_ERROR;
-        }
+        
+#elif defined(IP_TRANSPARENT)       
+	if (setsockopt(s, IPPROTO_IP, IP_TRANSPARENT,
+		(const void *) &value, sizeof(int)) == -1)
+	{
+	    ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
+		"setsockopt(IP_TRANSPARENT) failed");
+	    return NGX_ERROR;
+	}
 
 #endif
 


### PR DESCRIPTION
FreeBSD define IP_BINDANY in freebsd/netinet/in.h, and Linux define IP_TRANSPARENT in <linux/in.h>.
Fstack_Nginx may use wrong defination when running on Linux.
Fstack should only support IP_BINDANY.