### PR TITLE
F stack aarch64

### DIFF
--- a/freebsd/arm64/include/pcpu.h
+++ b/freebsd/arm64/include/pcpu.h
@@ -64,6 +64,7 @@ get_curthread(void)
 }
 
 #define	curthread get_curthread()
+#undef	curthread
 
 #define	PCPU_GET(member)	(get_pcpu()->pc_ ## member)
 #define	PCPU_ADD(member, value)	(get_pcpu()->pc_ ## member += (value))

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -24,18 +24,18 @@ FF_KNI=1
 #FF_IPFW=1
 
 ifeq ($(FF_DPDK),)
-ifeq (${MACHINE_CPUARCH},aarch64)
+ifeq (${shell uname -m},aarch64)
     FF_DPDK=${TOPDIR}/dpdk/build
 else
-    #FF_DPDK=${TOPDIR}/dpdk/x86_64-native-linuxapp-gcc
+    FF_DPDK=${TOPDIR}/dpdk/x86_64-native-linuxapp-gcc
 endif
 endif
 
 ifdef RTE_SDK
-ifeq (${MACHINE_CPUARCH},aarch64) 
+ifeq (${shell uname -m},aarch64) 
     FF_DPDK=${RTE_SDK}/build
 else
-    #FF_DPDK=${RTE_SDK}/x86_64-native-linuxapp-gcc
+    FF_DPDK=${RTE_SDK}/x86_64-native-linuxapp-gcc
 endif
 endif
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -24,11 +24,19 @@ FF_KNI=1
 #FF_IPFW=1
 
 ifeq ($(FF_DPDK),)
-    FF_DPDK=${TOPDIR}/dpdk/x86_64-native-linuxapp-gcc
+ifeq (${MACHINE_CPUARCH},aarch64)
+    FF_DPDK=${TOPDIR}/dpdk/build
+else
+    #FF_DPDK=${TOPDIR}/dpdk/x86_64-native-linuxapp-gcc
+endif
 endif
 
 ifdef RTE_SDK
-    FF_DPDK=${RTE_SDK}/x86_64-native-linuxapp-gcc
+ifeq (${MACHINE_CPUARCH},aarch64) 
+    FF_DPDK=${RTE_SDK}/build
+else
+    #FF_DPDK=${RTE_SDK}/x86_64-native-linuxapp-gcc
+endif
 endif
 
 DPDK_CFLAGS= -Wall -Werror -include ${FF_DPDK}/include/rte_config.h
@@ -90,6 +98,13 @@ ifneq (${COMPILER_TYPE},clang)
 CFLAGS += -mno-thumb-interwork
 endif
 
+endif
+
+#
+# fix the MACHINE_CPUARCH to match the FreeBSD directory name
+#
+ifeq (${MACHINE_CPUARCH},aarch64)
+MACHINE_CPUARCH=arm64
 endif
 
 
@@ -262,7 +277,7 @@ KERN_MHEADERS+=		\
 KERN_MSRCS+=		\
 	linker_if.m
 
-
+ifeq (${MACHINE_CPUARCH},arm64)
 LIBKERN_SRCS+=		 \
 	bcd.c		 \
 	crc32.c          \
@@ -270,7 +285,19 @@ LIBKERN_SRCS+=		 \
 	jenkins_hash.c   \
 	strlcpy.c	 \
 	strnlen.c        \
-	zlib.c
+	zlib.c		 \
+	fls.c		 \
+	flsl.c
+else
+LIBKERN_SRCS+=		 \
+	bcd.c		 \
+	crc32.c          \
+	inet_ntoa.c	 \
+	jenkins_hash.c   \
+	strlcpy.c	 \
+	strnlen.c        \
+	zlib.c		 
+endif
 
 
 MACHINE_SRCS+=		 \

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -23,8 +23,10 @@ FF_KNI=1
 #FF_NETGRAPH=1
 #FF_IPFW=1
 
+include ${TOPDIR}/mk/kern.pre.mk
+
 ifeq ($(FF_DPDK),)
-ifeq (${shell uname -m},aarch64)
+ifeq (${MACHINE_CPUARCH},aarch64)
     FF_DPDK=${TOPDIR}/dpdk/build
 else
     FF_DPDK=${TOPDIR}/dpdk/x86_64-native-linuxapp-gcc
@@ -32,7 +34,7 @@ endif
 endif
 
 ifdef RTE_SDK
-ifeq (${shell uname -m},aarch64) 
+ifeq (${MACHINE_CPUARCH},aarch64) 
     FF_DPDK=${RTE_SDK}/build
 else
     FF_DPDK=${RTE_SDK}/x86_64-native-linuxapp-gcc
@@ -44,8 +46,6 @@ DPDK_CFLAGS+= -march=native -DRTE_MACHINE_CPUFLAG_SSE -DRTE_MACHINE_CPUFLAG_SSE2
 DPDK_CFLAGS+= -DRTE_MACHINE_CPUFLAG_SSSE3 -DRTE_MACHINE_CPUFLAG_SSE4_1 -DRTE_MACHINE_CPUFLAG_SSE4_2
 DPDK_CFLAGS+= -DRTE_COMPILE_TIME_CPUFLAGS=RTE_CPUFLAG_SSE,RTE_CPUFLAG_SSE2,RTE_CPUFLAG_SSE3,RTE_CPUFLAG_SSSE3,RTE_CPUFLAG_SSE4_1,RTE_CPUFLAG_SSE4_2
 DPDK_CFLAGS+= -I${FF_DPDK}/include
-
-include ${TOPDIR}/mk/kern.pre.mk
 
 KERNPREINCLUDES:= ${INCLUDES}
 INCLUDES= -I${OVERRIDE_INCLUDES_ROOT} ${KERNPREINCLUDES}

--- a/mk/compiler.mk
+++ b/mk/compiler.mk
@@ -4,7 +4,7 @@
 
 ifndef COMPILER_TYPE
   ifeq ($(patsubst gcc%,gcc,$(notdir ${CC})),gcc)
-COMPILER_TYPE:=	gcc  
+COMPILER_TYPE:= gcc
   else ifeq ($(notdir ${CC}), clang)
 COMPILER_TYPE:=	clang
   else

--- a/mk/kern.mk
+++ b/mk/kern.mk
@@ -101,6 +101,10 @@ CFLAGS+=
 INLINE_LIMIT?=	8000
 endif
 
+ifeq (${MACHINE_CPUARCH},arm64)
+INLINE_LIMIT?=	15000
+endif
+
 #
 # GCC SSP support
 #


### PR DESCRIPTION
Hi,

We recently enable and test f_stack on our arm64 platform.

In out tests, there are some modifications to make f_stack run on arm64.
Patch 1 adds arm64 compiler options to support native compilation on arm64,
patch 2 fixes the  -Werror=unused-but-set-variable errors with gcc compilers (no only on arm64),
patch 3 fixes the segmentation faults on arm64 platform when nginx starts up.

The performance of nginx and redis are promising.
Compared with kernel stack, we get throughout improvements for about 20% of nginx and 35% of redis.

Hope these patches would merged into f_stack mainline for others want to test on arm64.

Thanks & Best Regards.
