### PR TITLE
Fix the IP and UDP/TCP Checksum offloading error when sending packets

### DIFF
--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -651,12 +651,15 @@ init_port_start(void)
 
         if ((dev_info.tx_offload_capa & DEV_TX_OFFLOAD_IPV4_CKSUM)) {
             printf("TX ip checksum offload supported\n");
+            port_conf.txmode.offloads |= DEV_TX_OFFLOAD_IPV4_CKSUM;
             pconf->hw_features.tx_csum_ip = 1;
         }
 
         if ((dev_info.tx_offload_capa & DEV_TX_OFFLOAD_UDP_CKSUM) &&
             (dev_info.tx_offload_capa & DEV_TX_OFFLOAD_TCP_CKSUM)) {
             printf("TX TCP&UDP checksum offload supported\n");
+            port_conf.txmode.offloads |= DEV_TX_OFFLOAD_UDP_CKSUM;
+            port_conf.txmode.offloads |= DEV_TX_OFFLOAD_TCP_CKSUM;
             pconf->hw_features.tx_csum_l4 = 1;
         }
 


### PR DESCRIPTION
Add the following offload flags to the port configuration:
1. DEV_TX_OFFLOAD_IPV4_CKSUM
2. DEV_TX_OFFLOAD_UDP_CKSUM
3. DEV_TX_OFFLOAD_TCP_CKSUM
to enable IP and UDP/TCP checksum offload to DPDK port.

Originally when sending packets, the IP checksum field is '0' which means no valid IP checksum field is inserted.
For issue: https://github.com/F-Stack/f-stack/issues/317

Signed-off-by: trevortao <trevor.tao@arm.com>