### PR TITLE
support more than 32 processes; support 52bytes rsskey; compile failed.

### DIFF
--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -113,7 +113,7 @@ parse_lcore_mask(struct ff_config *cfg, const char *coremask)
             if ((1 << j) & val) {
                 proc_lcore[count] = idx;
                 if (cfg->dpdk.proc_id == count) {
-                    sprintf(buf, "%x", 1<<idx);
+                    sprintf(buf, "%llx", (unsigned long long)1<<idx);
                     cfg->dpdk.proc_mask = strdup(buf);
                 }
                 count++;

--- a/lib/ff_dpdk_kni.c
+++ b/lib/ff_dpdk_kni.c
@@ -334,6 +334,10 @@ protocol_filter_udp(const void* data,uint16_t len)
 #ifndef IPPROTO_SHIM6
 #define IPPROTO_SHIM6   140
 #endif
+
+#ifndef IPPROTO_MH
+#define IPPROTO_MH   135
+#endif
 static int
 get_ipv6_hdr_len(uint8_t *proto, void *data, uint16_t len)
 {


### PR DESCRIPTION
ff_config.c：L116   use long long unsigned type to support binding more than 32 cores.
ff_dpdk_if.c: Add new hash key array to support X710 nic.
ff_dpdk_kni.c: compile faile,  IPPROTO_MH   should be defined.