### PR TITLE
support more than 32 processes; support 52bytes rsskey; compile failed.

### DIFF
--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -113,7 +113,7 @@ parse_lcore_mask(struct ff_config *cfg, const char *coremask)
             if ((1 << j) & val) {
                 proc_lcore[count] = idx;
                 if (cfg->dpdk.proc_id == count) {
-                    sprintf(buf, "%x", 1<<idx);
+                    sprintf(buf, "%llx", (unsigned long long)1<<idx);
                     cfg->dpdk.proc_mask = strdup(buf);
                 }
                 count++;

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -572,7 +572,7 @@ init_port_start(void)
         if (dev_info.hash_key_size == 52) {
             port_conf.rx_adv_conf.rss_conf.rss_key = default_rsskey_52bytes;
             port_conf.rx_adv_conf.rss_conf.rss_key_len = 52;
-		    use_rsskey_52bytes = 1;
+	    use_rsskey_52bytes = 1;
         }else{
             port_conf.rx_adv_conf.rss_conf.rss_key = default_rsskey_40bytes;
             port_conf.rx_adv_conf.rss_conf.rss_key_len = 40;
@@ -1652,12 +1652,12 @@ ff_rss_check(void *softc, uint32_t saddr, uint32_t daddr,
     datalen += sizeof(dport);
 
     uint32_t hash = 0;
-	if ( !use_rsskey_52bytes )
-	    hash = toeplitz_hash(sizeof(default_rsskey_40bytes), 
-	        default_rsskey_40bytes, datalen, data);
-	else
-	    hash = toeplitz_hash(sizeof(default_rsskey_52bytes), 
-	        default_rsskey_52bytes, datalen, data);
+    if ( !use_rsskey_52bytes )
+        hash = toeplitz_hash(sizeof(default_rsskey_40bytes), 
+            default_rsskey_40bytes, datalen, data);
+    else
+        hash = toeplitz_hash(sizeof(default_rsskey_52bytes), 
+	  default_rsskey_52bytes, datalen, data);
     return ((hash & (reta_size - 1)) % nb_queues) == queueid;
 }
 

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -1657,7 +1657,7 @@ ff_rss_check(void *softc, uint32_t saddr, uint32_t daddr,
             default_rsskey_40bytes, datalen, data);
     else
         hash = toeplitz_hash(sizeof(default_rsskey_52bytes), 
-	  default_rsskey_52bytes, datalen, data);
+	    default_rsskey_52bytes, datalen, data);
     return ((hash & (reta_size - 1)) % nb_queues) == queueid;
 }
 

--- a/lib/ff_dpdk_kni.c
+++ b/lib/ff_dpdk_kni.c
@@ -334,6 +334,10 @@ protocol_filter_udp(const void* data,uint16_t len)
 #ifndef IPPROTO_SHIM6
 #define IPPROTO_SHIM6   140
 #endif
+
+#ifndef IPPROTO_MH
+#define IPPROTO_MH   135
+#endif
 static int
 get_ipv6_hdr_len(uint8_t *proto, void *data, uint16_t len)
 {


### PR DESCRIPTION
ff_config.c：L116 use long long unsigned type to support binding more than 32 cores.
ff_dpdk_if.c: Add new hash key array to support X710 nic.
ff_dpdk_kni.c: compile faile, IPPROTO_MH should be defined.