### PR TITLE
lib/ff_config.c : Fix data overflow in more than 64 cores

### DIFF
--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -69,12 +69,13 @@ xdigit2val(unsigned char c)
 static int
 parse_lcore_mask(struct ff_config *cfg, const char *coremask)
 {
-    int i, j, idx = 0;
+    int i, j, idx = 0, shift = 0, zero_num = 0;
     unsigned count = 0;
     char c;
     int val;
     uint16_t *proc_lcore;
     char buf[RTE_MAX_LCORE] = {0};
+    char zero[RTE_MAX_LCORE] = {0};
 
     if (coremask == NULL)
         return 0;
@@ -113,9 +114,12 @@ parse_lcore_mask(struct ff_config *cfg, const char *coremask)
             if ((1 << j) & val) {
                 proc_lcore[count] = idx;
                 if (cfg->dpdk.proc_id == count) {
-                    sprintf(buf, "%llx", (unsigned long long)1<<idx);
-                    cfg->dpdk.proc_mask = strdup(buf);
-                }
+		    zero_num = idx >> 2;
+                    shift = idx & 0x3;
+                    memset(zero,'0',zero_num);
+                    sprintf(buf, "%llx%s", (unsigned long long)1<<shift, zero);
+                    cfg->dpdk.proc_mask = strdup(buf);                
+		}
                 count++;
             }
         }


### PR DESCRIPTION
In parse_lcore_mask(), the unsigned long long type will overflow when core number more than 64. So I modified the code and it worked well. Please confirm if it can change this way.If there is something wrong, please tell me ,thanks.