### PR TITLE
modify dump codes. 

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -73,10 +73,10 @@ savelen= 16777216
 # Correspond to dpdk.port_list's index: port0, port1...
 
 [port0]
-addr=192.168.4.69
+addr=192.168.1.2
 netmask=255.255.225.0
-broadcast=192.168.4.255
-gateway=192.168.4.1
+broadcast=192.168.1.255
+gateway=192.168.1.1
 
 # lcore list used to handle this port
 # the format is same as port_list

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 [dpdk]
 # Hexadecimal bitmask of cores to run on.
-lcore_mask=1
+lcore_mask=2
 
 # Number of memory channels.
 channel=4
@@ -61,13 +61,22 @@ nb_vdev=0
 # Number of bond.
 nb_bond=0
 
+# Each core write into own pcap file, which is open one time, close one time if enough.
+# Support dump the first snaplen bytes of each packet.
+# if pcap file is lager than savelen bytes, it will be closed and next file was dumped into.
+[pcap]
+enable = 0
+snaplen= 96
+savelen= 16777216
+
 # Port config section
 # Correspond to dpdk.port_list's index: port0, port1...
+
 [port0]
-addr=192.168.1.2
+addr=192.168.4.69
 netmask=255.255.225.0
-broadcast=192.168.1.255
-gateway=192.168.1.1
+broadcast=192.168.4.255
+gateway=192.168.4.1
 
 # lcore list used to handle this port
 # the format is same as port_list

--- a/config.ini
+++ b/config.ini
@@ -1,6 +1,6 @@
 [dpdk]
 # Hexadecimal bitmask of cores to run on.
-lcore_mask=2
+lcore_mask=1
 
 # Number of memory channels.
 channel=4
@@ -71,7 +71,6 @@ savelen= 16777216
 
 # Port config section
 # Correspond to dpdk.port_list's index: port0, port1...
-
 [port0]
 addr=192.168.1.2
 netmask=255.255.225.0

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -623,7 +623,7 @@ ini_parse_handler(void* user, const char* section, const char* name,
         } else if (strcmp(name, "enable") == 0) {
             pconfig->pcap.enable = (uint16_t)atoi(value);
         } else if (strcmp(name, "savepath") == 0) {
-        	pconfig->pcap.save_path = strdup(value);
+            pconfig->pcap.save_path = strdup(value);
         }
     }
 

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -815,9 +815,9 @@ ff_check_config(struct ff_config *cfg)
     }
 
     if ( cfg->pcap.save_len < PCAP_SAVE_MINLEN )
-    	cfg->pcap.save_len = PCAP_SAVE_MINLEN;
-	if (cfg->pcap.snap_len < PCAP_SNAP_MINLEN)
-    	cfg->pcap.snap_len = PCAP_SNAP_MINLEN;
+        cfg->pcap.save_len = PCAP_SAVE_MINLEN;
+    if (cfg->pcap.snap_len < PCAP_SNAP_MINLEN)
+        cfg->pcap.snap_len = PCAP_SNAP_MINLEN;
     if ( cfg->pcap.save_path==NULL || strlen(cfg->pcap.save_path) ==0)
         cfg->pcap.save_path = strdup(".");
 

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -615,6 +615,16 @@ ini_parse_handler(void* user, const char* section, const char* name,
         return vdev_cfg_handler(pconfig, section, name, value);
     } else if (strncmp(section, "bond", 4) == 0) {
         return bond_cfg_handler(pconfig, section, name, value);
+    } else if (strcmp(section, "pcap") == 0) {
+        if (strcmp(name, "snaplen") == 0) {
+            pconfig->pcap.snap_len = (uint16_t)atoi(value);            
+        } else if (strcmp(name, "savelen") == 0) {
+            pconfig->pcap.save_len = (uint32_t)atoi(value);            
+        } else if (strcmp(name, "enable") == 0) {
+            pconfig->pcap.enable = (uint16_t)atoi(value);
+        } else if (strcmp(name, "savepath") == 0) {
+        	pconfig->pcap.save_path = strdup(value);
+        }
     }
 
     return 1;
@@ -803,6 +813,13 @@ ff_check_config(struct ff_config *cfg)
             return -1;
         }
     }
+
+    if ( cfg->pcap.save_len < PCAP_SAVE_MINLEN )
+    	cfg->pcap.save_len = PCAP_SAVE_MINLEN;
+	if (cfg->pcap.snap_len < PCAP_SNAP_MINLEN)
+    	cfg->pcap.snap_len = PCAP_SNAP_MINLEN;
+    if ( cfg->pcap.save_path==NULL || strlen(cfg->pcap.save_path) ==0)
+        cfg->pcap.save_path = strdup(".");
 
     #define CHECK_VALID(n) \
         do { \

--- a/lib/ff_config.h
+++ b/lib/ff_config.h
@@ -35,6 +35,8 @@ extern "C" {
 #define DPDK_CONFIG_NUM 16
 #define DPDK_CONFIG_MAXLEN 256
 #define DPDK_MAX_LCORE 128
+#define PCAP_SNAP_MINLEN 94
+#define PCAP_SAVE_MINLEN (2<<22)
 
 extern int dpdk_argc;
 extern char *dpdk_argv[DPDK_CONFIG_NUM + 1];
@@ -60,6 +62,8 @@ struct ff_port_cfg {
     char *broadcast;
     char *gateway;
     char *pcap;
+    uint16_t snaplen;
+    uint32_t savelen;
 
     int nb_lcores;
     int nb_slaves;
@@ -163,6 +167,13 @@ struct ff_config {
         int fd_reserve;
         int mem_size;
     } freebsd;
+
+    struct {
+		uint16_t enable;
+		uint16_t snap_len;
+		uint32_t save_len;
+		char*	 save_path;
+    } pcap;
 };
 
 extern struct ff_config ff_global_cfg;

--- a/lib/ff_config.h
+++ b/lib/ff_config.h
@@ -169,10 +169,10 @@ struct ff_config {
     } freebsd;
 
     struct {
-		uint16_t enable;
-		uint16_t snap_len;
-		uint32_t save_len;
-		char*	 save_path;
+        uint16_t enable;
+        uint16_t snap_len;
+        uint32_t save_len;
+        char*	 save_path;
     } pcap;
 };
 

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -276,7 +276,7 @@ init_lcore_conf(void)
 
         /* Enable pcap dump */
         if (ff_global_cfg.pcap.enable) {
-        	ff_enable_pcap(ff_global_cfg.pcap.save_path, ff_global_cfg.pcap.snap_len);
+            ff_enable_pcap(ff_global_cfg.pcap.save_path, ff_global_cfg.pcap.snap_len);
         }
 
         lcore_conf.nb_queue_list[port_id] = pconf->nb_lcores;
@@ -1328,7 +1328,8 @@ send_burst(struct lcore_conf *qconf, uint16_t n, uint8_t port)
     if (unlikely(ff_global_cfg.pcap.enable)) {
         uint16_t i;
         for (i = 0; i < n; i++) {
-           ff_dump_packets( ff_global_cfg.pcap.save_path, m_table[i], ff_global_cfg.pcap.snap_len, ff_global_cfg.pcap.save_len);
+            ff_dump_packets( ff_global_cfg.pcap.save_path, m_table[i], 
+               ff_global_cfg.pcap.snap_len, ff_global_cfg.pcap.save_len);
         }
     }
     

--- a/lib/ff_dpdk_pcap.c
+++ b/lib/ff_dpdk_pcap.c
@@ -106,7 +106,8 @@ ff_dump_packets(const char* dump_path, struct rte_mbuf* pkt, uint16_t snap_len, 
     while(pkt != NULL && out_len <= snap_len) {
         wr_len = snap_len - out_len;
         wr_len = wr_len > pkt->data_len ? pkt->data_len : wr_len ;
-        out_len += wr_len * fwrite(rte_pktmbuf_mtod(pkt, char*), wr_len, 1, g_pcap_fp);//pkt->data_len, 1, fp);
+        fwrite(rte_pktmbuf_mtod(pkt, char*), wr_len, 1, g_pcap_fp);
+        out_len += wr_len;
         pkt = pkt->next;
     }
     g_flen += out_len;

--- a/lib/ff_dpdk_pcap.h
+++ b/lib/ff_dpdk_pcap.h
@@ -30,8 +30,8 @@
 #include <rte_config.h>
 #include <rte_mbuf.h>
 
-int ff_enable_pcap(const char* dump_path);
-int ff_dump_packets(const char* dump_path, struct rte_mbuf *pkt);
+int ff_enable_pcap(const char* dump_path, uint16_t snap_len);
+int ff_dump_packets(const char* dump_path, struct rte_mbuf *pkt, uint16_t snap_len, uint32_t f_maxlen);
 
 
 #endif /* ifndef _FSTACK_DPDK_PCAP_H */

--- a/lib/ff_memory.h
+++ b/lib/ff_memory.h
@@ -89,7 +89,7 @@ struct lcore_conf {
     uint16_t tx_port_id[RTE_MAX_ETHPORTS];
     uint16_t tx_queue_id[RTE_MAX_ETHPORTS];
     struct mbuf_table tx_mbufs[RTE_MAX_ETHPORTS];
-    char *pcap[RTE_MAX_ETHPORTS];
+    //char *pcap[RTE_MAX_ETHPORTS];
 } __rte_cache_aligned;
 
 #ifdef FF_USE_PAGE_ARRAY


### PR DESCRIPTION
Each core writes it's own dump file, without fclose()/fopen while dumping. It improve performance greately.
Support configuring the snap length when dump packets.
Support configuring pcap file size, in order to avoid write too much into single file. 