### PR TITLE
For IPv6, Build ff_dpdk_kni.c if FF_KNI is defined

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -486,7 +486,7 @@ NETINET6_SRCS+=		\
 	#ip6_ipsec.c
 	#sctp6_usrreq.c
 	#in6_rss.c
-ifndef FF_KNI
+ifdef FF_KNI
 FF_HOST_SRCS+=         \
         ff_dpdk_kni.c
 endif


### PR DESCRIPTION
In IPv6 case, whether build ff_dpdk_kni.c is not controled by FF_KNI.