### PR TITLE
When compiling with GCC we hit compilation error of taking address of packed member.

### DIFF
--- a/mk/kern.mk
+++ b/mk/kern.mk
@@ -35,7 +35,7 @@ CWARNEXTRA?=	-Wno-error-tautological-compare -Wno-error-empty-body \
 endif
 
 ifeq (${COMPILER_TYPE},gcc)
-CWARNEXTRA?=	-Wno-unused-but-set-variable
+CWARNEXTRA?=	-Wno-unused-but-set-variable -Wno-address-of-packed-member
 endif
 
 #


### PR DESCRIPTION
This adds -Wno-address-of-packed-member to avoid this warning.