### PR TITLE
Config: Support parse "--file-prefix"&"--pci-whitelist" for multi-processes

### DIFF
--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -567,6 +567,10 @@ ini_parse_handler(void* user, const char* section, const char* name,
         return parse_lcore_mask(pconfig, pconfig->dpdk.lcore_mask);
     } else if (MATCH("dpdk", "base_virtaddr")) {
         pconfig->dpdk.base_virtaddr= strdup(value);
+    } else if (MATCH("dpdk", "file_prefix")) {
+        pconfig->dpdk.file_prefix = strdup(value);
+    } else if (MATCH("dpdk", "pci_whitelist")) {
+        pconfig->dpdk.pci_whitelist = strdup(value);
     } else if (MATCH("dpdk", "port_list")) {
         return parse_port_list(pconfig, value);
     } else if (MATCH("dpdk", "nb_vdev")) {
@@ -664,6 +668,14 @@ dpdk_args_setup(struct ff_config *cfg)
         sprintf(temp, "--base-virtaddr=%s", cfg->dpdk.base_virtaddr);
         dpdk_argv[n++] = strdup(temp);
     }
+    if (cfg->dpdk.file_prefix) {
+        sprintf(temp, "--file-prefix=container%s", cfg->dpdk.file_prefix);
+        dpdk_argv[n++] = strdup(temp);
+    }
+    if (cfg->dpdk.pci_whitelist) {
+        sprintf(temp, "--pci-whitelist=%s", cfg->dpdk.pci_whitelist);
+        dpdk_argv[n++] = strdup(temp);
+    }
 
     if (cfg->dpdk.nb_vdev) {
         for (i=0; i<cfg->dpdk.nb_vdev; i++) {
@@ -694,8 +706,10 @@ dpdk_args_setup(struct ff_config *cfg)
         }
         sprintf(temp, "--no-pci");
         dpdk_argv[n++] = strdup(temp);
-        sprintf(temp, "--file-prefix=container");
-        dpdk_argv[n++] = strdup(temp);
+        if (!cfg->dpdk.file_prefix) {
+            sprintf(temp, "--file-prefix=container");
+            dpdk_argv[n++] = strdup(temp);
+        }
     }
 
     if (cfg->dpdk.nb_bond) {

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -669,7 +669,7 @@ dpdk_args_setup(struct ff_config *cfg)
         dpdk_argv[n++] = strdup(temp);
     }
     if (cfg->dpdk.file_prefix) {
-        sprintf(temp, "--file-prefix=container%s", cfg->dpdk.file_prefix);
+        sprintf(temp, "--file-prefix=container-%s", cfg->dpdk.file_prefix);
         dpdk_argv[n++] = strdup(temp);
     }
     if (cfg->dpdk.pci_whitelist) {

--- a/lib/ff_config.h
+++ b/lib/ff_config.h
@@ -116,6 +116,12 @@ struct ff_config {
         /* specify base virtual address to map. */
         char *base_virtaddr;
 
+        /* allow processes that do not want to co-operate to have different memory regions */
+        char *file_prefix;
+
+        /* load an external driver */
+        char *pci_whitelist;
+
         int nb_channel;
         int memory;
         int no_huge;


### PR DESCRIPTION
修改f-stack配置文件识别功能，支持 parse file-prefix&pci-whitelist两个配置项，解决多进程绑定同CPU核心时内存异常问题：a. 同物理机上多个容器分别部署DPDK程序，共用物理机Hugepage；b. 类似Nginx的reload过程，多进程绑定相同CPU核心，共用Hugepage

1. DPDK支持多进程绑定同一个逻辑CPU时，常用到--file-prefix配置参数，以避免两个进程使用共享内存时，物理内存冲突现象
--file-prefix: Use a different shared data file prefix for a DPDK process. This option allows running multiple independent DPDK primary/secondary processes under different prefixes.

2. DPDK程序在容器化场景下，需要绑定类似VF的PCI设备，需要使用--pci-whitelist参数进行指定，例如容器中识别SR-IOV透传的VF设备
 –pci-whitelist domain: bus:devid:func: Add a PCI device in white list
