### PR TITLE
Replace deprecated filter api with generic flowapi

### DIFF
--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -900,7 +900,7 @@ port_flow_isolate(uint16_t port_id, int set)
 }
 
 static int
-create_tcp_flow(int port_id, uint16_t tcp_port) {
+create_tcp_flow(uint16_t port_id, uint16_t tcp_port) {
   struct rte_flow_attr attr = {.ingress = 1};
   struct ff_port_cfg *pconf = &ff_global_cfg.dpdk.port_cfgs[port_id];
   int nb_queues = pconf->nb_lcores;

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -1108,7 +1108,7 @@ ff_dpdk_init(int argc, char **argv)
 
     init_clock();
 #ifdef FF_FLOW_ISOLATE
-    //TODO: using config options replace magic number
+    //Recommend: using config options replace magic number
     ret = init_flow(0, 80);
     if (ret < 0) {
         rte_exit(EXIT_FAILURE, "init_port_flow failed\n");

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -994,7 +994,7 @@ create_tcp_flow(int port_id, uint16_t tcp_port) {
 }
 
 static int
-init_flow(void) {
+init_flow(uint16_t port_id, uint16_t tcp_port) {
   // struct ff_flow_cfg fcfg = ff_global_cfg.dpdk.flow_cfgs[0];
 
   // int i;
@@ -1003,9 +1003,6 @@ init_flow(void) {
   //         return 0;
   //     }
   // }
-  int port_id = 0;
-  uint16_t tcp_port = 80;
-  int set = 1;
 
   if(!create_tcp_flow(port_id, tcp_port)) {
       rte_exit(EXIT_FAILURE, "create tcp flow failed\n");
@@ -1111,7 +1108,8 @@ ff_dpdk_init(int argc, char **argv)
 
     init_clock();
 #ifdef FF_FLOW_ISOLATE
-    ret = init_flow();
+    //TODO: using config options replace magic number
+    ret = init_flow(0, 80);
     if (ret < 0) {
         rte_exit(EXIT_FAILURE, "init_port_flow failed\n");
     }

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -1108,7 +1108,7 @@ ff_dpdk_init(int argc, char **argv)
 
     init_clock();
 #ifdef FF_FLOW_ISOLATE
-    //Only give a example using port_id=0, tcp_port= 80. 
+    //Only give a example usage: port_id=0, tcp_port= 80. 
     //Recommend: 
     //1. init_flow should replace `set_rss_table` in `init_port_start` loop, This can set all NIC's port_id_list instead only 0 device(port_id).
     //2. using config options `tcp_port` replace magic number of 80

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -1108,7 +1108,10 @@ ff_dpdk_init(int argc, char **argv)
 
     init_clock();
 #ifdef FF_FLOW_ISOLATE
-    //Recommend: using config options replace magic number
+    //Only give a example using port_id=0, tcp_port= 80. 
+    //Recommend: 
+    //1. init_flow should replace `set_rss_table` in `init_port_start` loop, This can set all NIC's port_id_list instead only 0 device(port_id).
+    //2. using config options `tcp_port` replace magic number of 80
     ret = init_flow(0, 80);
     if (ret < 0) {
         rte_exit(EXIT_FAILURE, "init_port_flow failed\n");


### PR DESCRIPTION
As #562 says that I will give a RSS flow rule example, and replace deprecated filter api with generic flow api.
I use generic flow api implement a RSS rule, and multi lcore can load balance. I have tested nginx example in Intel & MLX5 devices

![image](https://user-images.githubusercontent.com/10736359/100423266-ad0e8580-30c6-11eb-9297-a4ef19054923.png)


Test1: Intel NIC
![image](https://user-images.githubusercontent.com/10736359/100357503-bb5d9280-302f-11eb-84d5-df52f0d8e4b2.png)

Test2: MLX5 NIC
![image](https://user-images.githubusercontent.com/10736359/100357565-cdd7cc00-302f-11eb-992a-bf5742c5db87.png)
#561 The implementation can support Flow Bifurcation on Mellanox ConnectX. `telnet` other port is enable, such as 22(ssh).


