### PR TITLE
Add support for multiple `pci_whitelist` in `config.ini`.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -41,6 +41,8 @@ symmetric_rss=0
 # PCI device enable list.
 # And driver options
 #pci_whitelist=02:00.0
+# for multiple PCI devices
+#pci_whilelist=02:00.0,03:00.0
 
 # enabled port list
 #

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -770,8 +770,14 @@ dpdk_args_setup(struct ff_config *cfg)
         dpdk_argv[n++] = strdup(temp);
     }
     if (cfg->dpdk.pci_whitelist) {
-        sprintf(temp, "--pci-whitelist=%s", cfg->dpdk.pci_whitelist);
-        dpdk_argv[n++] = strdup(temp);
+        char* token;
+        char* rest = cfg->dpdk.pci_whitelist;
+
+        while ((token = strtok_r(rest, ",", &rest))){
+            sprintf(temp, "--pci-whitelist=%s", token);
+            dpdk_argv[n++] = strdup(temp);
+        }
+
     }
 
     if (cfg->dpdk.nb_vdev) {


### PR DESCRIPTION
Previously, a user could set only one pci-whitelist argument, additional pci-whitelist arguments override the prior ones. This feature allows users to add numerous pci-whitelists in a comma-separated format.
