### PR TITLE
Add support to set interface name of each port in `config.ini`.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -84,6 +84,8 @@ addr=192.168.1.2
 netmask=255.255.225.0
 broadcast=192.168.1.255
 gateway=192.168.1.1
+# set interface name, Optional parameter.
+#if_name=eno7
 
 # IPv6 net addr, Optional parameters.
 #addr6=ff::02

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -489,7 +489,9 @@ port_cfg_handler(struct ff_config *cfg, const char *section,
         cur->port_id = portid;
     }
 
-    if (strcmp(name, "addr") == 0) {
+    if (strcmp(name, "ifc_name") == 0) {
+        cur->ifname = strdup(value);
+    } else if (strcmp(name, "addr") == 0) {
         cur->addr = strdup(value);
     } else if (strcmp(name, "netmask") == 0) {
         cur->netmask = strdup(value);

--- a/lib/ff_config.h
+++ b/lib/ff_config.h
@@ -56,6 +56,7 @@ struct ff_hw_features {
 
 struct ff_port_cfg {
     char *name;
+    char *ifname;
     uint8_t port_id;
     uint8_t mac[6];
     struct ff_hw_features hw_features;

--- a/lib/ff_veth.c
+++ b/lib/ff_veth.c
@@ -617,7 +617,11 @@ ff_veth_attach(struct ff_port_cfg *cfg)
     }
     memset(sc, 0, sizeof(struct ff_veth_softc));
 
-    snprintf(sc->host_ifname, sizeof(sc->host_ifname), ff_IF_NAME, cfg->port_id);
+    if(cfg->ifname){
+        snprintf(sc->host_ifname, sizeof(sc->host_ifname), "%s", cfg->ifname);
+    } else {
+        snprintf(sc->host_ifname, sizeof(sc->host_ifname), ff_IF_NAME, cfg->port_id);
+    }
 
     error = ff_veth_config(sc, cfg);
     if (0 != error) {


### PR DESCRIPTION
Instead of the default interface name supplied by f-stack, the user can now set their own interface name. The **if_name** option allows the user to provide the interface name. This choice is optional for the user to set.