### PR TITLE
Corrections in config code

### DIFF
--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -367,7 +367,7 @@ parse_port_slave_list(struct ff_port_cfg *cfg, const char *v_str)
 }
 
 static int
-vip_cfg_hander(struct ff_port_cfg *cur)
+vip_cfg_handler(struct ff_port_cfg *cur)
 {
     //vip cfg
     int ret;
@@ -375,7 +375,7 @@ vip_cfg_hander(struct ff_port_cfg *cur)
 
     ret = rte_strsplit(cur->vip_addr_str, strlen(cur->vip_addr_str), &vip_addr_array[0], VIP_MAX_NUM, ';');
     if (ret <= 0) {
-        fprintf(stdout, "vip_cfg_hander nb_vip is 0, not set vip_addr or set invalid vip_addr %s\n",
+        fprintf(stdout, "vip_cfg_handler nb_vip is 0, not set vip_addr or set invalid vip_addr %s\n",
             cur->vip_addr_str);
         return 1;
     }
@@ -384,7 +384,7 @@ vip_cfg_hander(struct ff_port_cfg *cur)
 
     cur->vip_addr_array = (char **)calloc(cur->nb_vip, sizeof(char *));
     if (cur->vip_addr_array == NULL) {
-        fprintf(stderr, "vip_cfg_hander malloc failed\n");
+        fprintf(stderr, "vip_cfg_handler malloc failed\n");
         goto err;
     }
 
@@ -404,7 +404,7 @@ err:
 
 #ifdef INET6
 static int
-vip6_cfg_hander(struct ff_port_cfg *cur)
+vip6_cfg_handler(struct ff_port_cfg *cur)
 {
     //vip6 cfg
     int ret;
@@ -413,7 +413,7 @@ vip6_cfg_hander(struct ff_port_cfg *cur)
     ret = rte_strsplit(cur->vip_addr6_str, strlen(cur->vip_addr6_str),
                                     &vip_addr6_array[0], VIP_MAX_NUM, ';');
     if (ret == 0) {
-        fprintf(stdout, "vip6_cfg_hander nb_vip6 is 0, not set vip_addr6 or set invalid vip_addr6 %s\n",
+        fprintf(stdout, "vip6_cfg_handler nb_vip6 is 0, not set vip_addr6 or set invalid vip_addr6 %s\n",
             cur->vip_addr6_str);
         return 1;
     }
@@ -422,7 +422,7 @@ vip6_cfg_hander(struct ff_port_cfg *cur)
 
     cur->vip_addr6_array = (char **) calloc(cur->nb_vip6, sizeof(char *));
     if (cur->vip_addr6_array == NULL) {
-        fprintf(stderr, "port_cfg_handler malloc failed\n");
+        fprintf(stderr, "vip6_cfg_handler malloc failed\n");
         goto fail;
     }
 
@@ -506,7 +506,7 @@ port_cfg_handler(struct ff_config *cfg, const char *section,
     } else if (strcmp(name, "vip_addr") == 0) {
         cur->vip_addr_str = strdup(value);
         if (cur->vip_addr_str) {
-            return vip_cfg_hander(cur);
+            return vip_cfg_handler(cur);
         }
     } else if (strcmp(name, "vip_ifname") == 0) {
         cur->vip_ifname = strdup(value);

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -191,6 +191,7 @@ freebsd_conf_handler(struct ff_config *cfg, const char *section,
         }
     } else {
         fprintf(stderr, "freebsd conf section[%s] error\n", section);
+        free(newconf);
         return 0;
     }
 

--- a/lib/ff_config.c
+++ b/lib/ff_config.c
@@ -521,8 +521,8 @@ port_cfg_handler(struct ff_config *cfg, const char *section,
         cur->gateway6_str = strdup(value);
     } else if (strcmp(name, "vip_addr6") == 0) {
         cur->vip_addr6_str = strdup(value);
-        if (cur->vip_addr_str) {
-            return vip6_cfg_hander(cur);
+        if (cur->vip_addr6_str) {
+            return vip6_cfg_handler(cur);
         }
     } else if (0 == strcmp(name, "vip_prefix_len")) {
         cur->vip_prefix_len = atoi(value);


### PR DESCRIPTION
Corrected a couple of findings in `ff_config.c` regarding pointer checks, naming and memory handling.
Some changes might be trivial but done for code consistency.

- Correcting a pointer check of the config value for vip_addr6.
  Checking the IPv4 vip_addr pointer during handling of IPv6 might have given problems for IPv6 only configs.
- Avoid leaks after errors in the freebsd config handler.
  Freeing allocated memory in an error flow. Currently this would most likely not occur but a safeguard for future changes.
- Renaming vip6_cfg_hander() to vip6_cfg_handler().
  Includes a corrected log output that existed before the renaming.
