### PR TITLE
prevent ff_recvfrom() from corrupting *from passed by user in case of zero *fromlen 

### DIFF
--- a/lib/ff_syscall_wrapper.c
+++ b/lib/ff_syscall_wrapper.c
@@ -896,7 +896,7 @@ ff_recvfrom(int s, void *buf, size_t len, int flags,
     if (fromlen != NULL)
         *fromlen = msg.msg_namelen;
 
-    if (from)
+    if (from && msg.msg_namelen != 0)
         freebsd2linux_sockaddr(from, (struct sockaddr *)&bsdaddr);
 
     return (rc);


### PR DESCRIPTION
currently if *fromlen passed by user is zero the *from structure is filled with garbage values. The reason behind is that ```struct sockaddr_storage bsdaddr``` is made inside ff_recvfrom() and is passed to kern_recvit() to be filled. kern_recvit() does not touch  bsdaddr in case of zero *fromlen hence it has garbadge values. Later in freebsd2linux_sockaddr(),  bsdaddr is copied into *from which corrupts *from. 

The fix is to simply not copy bsdaddr into *from in case of zero *fromlen. This patch adds a simple check for that. 