### PR TITLE
Enable Flow Bifurcation

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -33,7 +33,7 @@ idle_sleep=0
 # if set 0, means send pkts immediately.
 # if set >100, will dealy 100 us.
 # unit: microseconds
-pkt_tx_delay=100
+pkt_tx_delay=0
 
 # use symmetric Receive-side Scaling(RSS) key, default: disabled.
 symmetric_rss=0

--- a/config.ini
+++ b/config.ini
@@ -85,10 +85,10 @@ savepath=.
 # Port config section
 # Correspond to dpdk.port_list's index: port0, port1...
 [port0]
-addr=192.168.1.2
-netmask=255.255.255.0
-broadcast=192.168.1.255
-gateway=192.168.1.1
+addr=10.250.136.21
+netmask=255.255.254.0
+broadcast=10.250.137.255
+gateway=10.250.137.254
 # set interface name, Optional parameter.
 #if_name=eno7
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -35,7 +35,7 @@ ifneq ($(TGT_OS),FreeBSD)
 FF_KNI=1
 endif
 
-#FF_FLOW_ISOLATE=1
+FF_FLOW_ISOLATE=1
 #FF_FDIR=1
 
 # NETGRAPH drivers ipfw

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -28,7 +28,7 @@ endif
 
 HOST_OS:=$(shell uname -s)
 
-DEBUG=-O0 -gdwarf-2 -g3 -Wno-format-truncation
+DEBUG=-O0 -gdwarf-2 -g3 -Wno-format-truncation -fPIC
 
 # No DPDK KNI support on FreeBSD
 ifneq ($(TGT_OS),FreeBSD)
@@ -665,6 +665,7 @@ libfstack.a: machine_includes ff_api.symlist ${MHEADERS} ${MSRCS} ${HOST_OBJS} $
 	objcopy --globalize-symbols=ff_api.symlist $*.ro
 	rm -f $@
 	ar -cqs $@ $*.ro ${HOST_OBJS}
+	${CC} -shared -o libfstack.so $*.ro -fPIC ${HOST_OBJS}
 	rm -f $*.ro
 
 ${HOST_OBJS}: %.o: %.c


### PR DESCRIPTION
Configure DPDK to only send packets that match a given IP to F-Stack and let the kernel handle the rest. This allows DPDK and non-DPDK applications to run on the same NIC and to use the same port numbers.