### PR TITLE
make it compilable under O2 optimization, pass gcc check

### DIFF
--- a/freebsd/kern/kern_uuid.c
+++ b/freebsd/kern/kern_uuid.c
@@ -163,7 +163,6 @@ kern_uuidgen(struct uuid *store, size_t count)
 		uuid.time.x.mid = (uint16_t)(time >> 32);
 		uuid.time.x.hi = ((uint16_t)(time >> 48) & 0xfff) | (1 << 12);
 		memcpy(store + n, &uuid, sizeof(struct uuid));
-		// store[n] = *(struct uuid *)&uuid;
 		time++;
 	}
 

--- a/freebsd/kern/kern_uuid.c
+++ b/freebsd/kern/kern_uuid.c
@@ -162,7 +162,8 @@ kern_uuidgen(struct uuid *store, size_t count)
 		uuid.time.x.low = (uint32_t)time;
 		uuid.time.x.mid = (uint16_t)(time >> 32);
 		uuid.time.x.hi = ((uint16_t)(time >> 48) & 0xfff) | (1 << 12);
-		store[n] = *(struct uuid *)&uuid;
+		memcpy(store + n, &uuid, sizeof(struct uuid));
+		// store[n] = *(struct uuid *)&uuid;
 		time++;
 	}
 

--- a/freebsd/net/if.c
+++ b/freebsd/net/if.c
@@ -594,7 +594,7 @@ if_alloc_domain(u_char type, int numa_domain)
 {
 	struct ifnet *ifp;
 	u_short idx;
-	void *old;
+	void *old = NULL;
 
 	KASSERT(numa_domain <= IF_NODOM, ("numa_domain too large"));
 	if (numa_domain == IF_NODOM)

--- a/freebsd/net/route/route_ifaddrs.c
+++ b/freebsd/net/route/route_ifaddrs.c
@@ -100,7 +100,7 @@ rib_handle_ifaddr_one(uint32_t fibnum, int cmd, struct rt_addrinfo *info)
 int
 rib_handle_ifaddr_info(uint32_t fibnum, int cmd, struct rt_addrinfo *info)
 {
-	int error, last_error = 0;
+	int error = 0, last_error = 0;
 	bool didwork = false;
 
 	if (V_rt_add_addr_allfibs == 0) {

--- a/freebsd/netinet/in_pcb.c
+++ b/freebsd/netinet/in_pcb.c
@@ -692,7 +692,7 @@ in_pcb_lport_dest(struct inpcb *inp, struct sockaddr *lsa, u_short *lportp,
 	struct in_addr laddr, faddr;
 #endif
 #ifdef INET6
-	struct in6_addr *laddr6, *faddr6;
+	struct in6_addr *laddr6 = NULL, *faddr6 = NULL;
 #endif
 
 	pcbinfo = inp->inp_pcbinfo;

--- a/freebsd/netinet/tcp_stacks/bbr.c
+++ b/freebsd/netinet/tcp_stacks/bbr.c
@@ -11395,7 +11395,7 @@ bbr_do_segment_nounlock(struct mbuf *m, struct tcphdr *th, struct socket *so,
     int32_t nxt_pkt, struct timeval *tv)
 {
 	int32_t thflags, retval;
-	uint32_t cts, lcts;
+	uint32_t cts, lcts = 0;
 	uint32_t tiwin;
 	struct tcpopt to;
 	struct tcp_bbr *bbr;
@@ -11957,7 +11957,7 @@ bbr_output_wtime(struct tcpcb *tp, const struct timeval *tv)
 	struct socket *so;
 	int32_t len;
 	uint32_t cts;
-	uint32_t recwin, sendwin;
+	uint32_t recwin = 0, sendwin;
 	int32_t sb_offset;
 	int32_t flags, abandon, error = 0;
 	struct tcp_log_buffer *lgb = NULL;

--- a/freebsd/netinet/tcp_stacks/rack.c
+++ b/freebsd/netinet/tcp_stacks/rack.c
@@ -11878,13 +11878,13 @@ static int
 rack_output(struct tcpcb *tp)
 {
 	struct socket *so;
-	uint32_t recwin;
+	uint32_t recwin = 0;
 	uint32_t sb_offset;
 	int32_t len, flags, error = 0;
 	struct mbuf *m;
 	struct mbuf *mb;
 	uint32_t if_hw_tsomaxsegcount = 0;
-	uint32_t if_hw_tsomaxsegsize;
+	uint32_t if_hw_tsomaxsegsize = 0;
 	int32_t segsiz, minseg;
 	long tot_len_this_send = 0;
 	struct ip *ip = NULL;

--- a/freebsd/netinet/tcp_stacks/rack_bbr_common.c
+++ b/freebsd/netinet/tcp_stacks/rack_bbr_common.c
@@ -248,7 +248,7 @@ ctf_process_inbound_raw(struct tcpcb *tp, struct socket *so, struct mbuf *m, int
 	 */
 	struct mbuf *m_save;
 	struct ether_header *eh;
-	struct tcphdr *th;
+	struct tcphdr *th = NULL;
 #ifdef INET6
 	struct ip6_hdr *ip6 = NULL;	/* Keep compiler happy. */
 #endif
@@ -257,10 +257,10 @@ ctf_process_inbound_raw(struct tcpcb *tp, struct socket *so, struct mbuf *m, int
 #endif
 	struct ifnet *ifp;
 	struct timeval tv;
-	int32_t retval, nxt_pkt, tlen, off;
+	int32_t retval, nxt_pkt, tlen = 0, off;
 	uint16_t etype;
-	uint16_t drop_hdrlen;
-	uint8_t iptos, no_vn=0, bpf_req=0;
+	uint16_t drop_hdrlen = 0;
+	uint8_t iptos = 0, no_vn=0, bpf_req=0;
 
 	NET_EPOCH_ASSERT();
 

--- a/freebsd/netinet/tcp_usrreq.c
+++ b/freebsd/netinet/tcp_usrreq.c
@@ -1006,16 +1006,16 @@ tcp_usr_send(struct socket *so, int flags, struct mbuf *m,
 {
 	struct epoch_tracker et;
 	int error = 0;
-	struct inpcb *inp;
+	struct inpcb *inp = NULL;
 	struct tcpcb *tp = NULL;
 #ifdef INET
 #ifdef INET6
 	struct sockaddr_in sin;
 #endif
-	struct sockaddr_in *sinp;
+	struct sockaddr_in *sinp = NULL;
 #endif
 #ifdef INET6
-	int isipv6;
+	int isipv6 = 0;
 #endif
 	u_int8_t incflagsav;
 	u_char vflagsav;

--- a/freebsd/netinet6/nd6.c
+++ b/freebsd/netinet6/nd6.c
@@ -1242,7 +1242,7 @@ nd6_is_new_addr_neighbor(const struct sockaddr_in6 *addr, struct ifnet *ifp)
 	struct sockaddr_in6 rt_key;
 	const struct sockaddr *dst6;
 	uint64_t genid;
-	int error, fibnum;
+	int error = 0, fibnum;
 
 	/*
 	 * A link-local address is always a neighbor.

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -705,6 +705,9 @@ init_port_start(void)
                     port_conf.txmode.offloads |= DEV_TX_OFFLOAD_TCP_TSO;
                     pconf->hw_features.tx_tso = 1;
                 }
+                else {
+                    printf("TSO is not supported\n");
+                }
             } else {
                 printf("TSO is disabled\n");
             }

--- a/lib/ff_route.c
+++ b/lib/ff_route.c
@@ -876,11 +876,12 @@ rt_getmetrics(const struct rtentry *rt, const struct nhop_object *nh,
 }
 
 static void
-init_sockaddrs_family(int family, struct sockaddr *dst, struct sockaddr *mask)
+// init_sockaddrs_family(int family, struct sockaddr *dst, struct sockaddr *mask)
+init_sockaddrs_family(int family, union sockaddr_union *dst, union sockaddr_union *mask)
 {
     if (family == AF_INET) {
-        struct sockaddr_in *dst4 = (struct sockaddr_in *)dst;
-        struct sockaddr_in *mask4 = (struct sockaddr_in *)mask;
+        struct sockaddr_in *dst4 = &(dst->sin);
+        struct sockaddr_in *mask4 = &(mask->sin);
 
         bzero(dst4, sizeof(struct sockaddr_in));
         bzero(mask4, sizeof(struct sockaddr_in));
@@ -892,8 +893,8 @@ init_sockaddrs_family(int family, struct sockaddr *dst, struct sockaddr *mask)
     }
 #ifdef INET6
     if (family == AF_INET6) {
-        struct sockaddr_in6 *dst6 = (struct sockaddr_in6 *)dst;
-        struct sockaddr_in6 *mask6 = (struct sockaddr_in6 *)mask;
+        struct sockaddr_in6 *dst6 = &(dst->sin6);
+        struct sockaddr_in6 *mask6 = &(mask->sin6);
 
         bzero(dst6, sizeof(struct sockaddr_in6));
         bzero(mask6, sizeof(struct sockaddr_in6));
@@ -944,7 +945,7 @@ update_rtm_from_rc(struct rt_addrinfo *info, struct rt_msghdr **prtm,
     rtm = *prtm;
     union sockaddr_union sa_dst, sa_mask;
     int family = info->rti_info[RTAX_DST]->sa_family;
-    init_sockaddrs_family(family, &sa_dst.sa, &sa_mask.sa);
+    init_sockaddrs_family(family, &sa_dst, &sa_mask);
     export_rtaddrs(rc->rc_rt, &sa_dst.sa, &sa_mask.sa);
 
     info->rti_info[RTAX_DST] = &sa_dst.sa;

--- a/lib/ff_route.c
+++ b/lib/ff_route.c
@@ -876,7 +876,6 @@ rt_getmetrics(const struct rtentry *rt, const struct nhop_object *nh,
 }
 
 static void
-// init_sockaddrs_family(int family, struct sockaddr *dst, struct sockaddr *mask)
 init_sockaddrs_family(int family, union sockaddr_union *dst, union sockaddr_union *mask)
 {
     if (family == AF_INET) {


### PR DESCRIPTION
Fix the problem that when `DEBUG` is commented out in `lib/Makefile`, the f-stack codes won't pass the compilation check under O2 optimization.
Tested with GCC 9.4.0, linux 5.4.204.