### PR TITLE
Dev

### DIFF
--- a/freebsd/netinet/tcp_stacks/bbr.c
+++ b/freebsd/netinet/tcp_stacks/bbr.c
@@ -13489,15 +13489,6 @@ send:
 				th->th_seq = htonl(tp->snd_max);
 				bbr_seq = tp->snd_max;
 			}
-		} else if (flags & TH_RST) {
-			/*
-			 * For a Reset send the last cum ack in sequence
-			 * (this like any other choice may still generate a
-			 * challenge ack, if a ack-update packet is in
-			 * flight).
-			 */
-			th->th_seq = htonl(tp->snd_una);
-			bbr_seq = tp->snd_una;
 		} else {
 			/*
 			 * len == 0 and not persist we use snd_max, sending

--- a/freebsd/netinet/tcp_stacks/rack.c
+++ b/freebsd/netinet/tcp_stacks/rack.c
@@ -13487,15 +13487,6 @@ send:
 		    rack->rc_in_persist) {
 			th->th_seq = htonl(tp->snd_nxt);
 			rack_seq = tp->snd_nxt;
-		} else if (flags & TH_RST) {
-			/*
-			 * For a Reset send the last cum ack in sequence
-			 * (this like any other choice may still generate a
-			 * challenge ack, if a ack-update packet is in
-			 * flight).
-			 */
-			th->th_seq = htonl(tp->snd_una);
-			rack_seq = tp->snd_una;
 		} else {
 			th->th_seq = htonl(tp->snd_max);
 			rack_seq = tp->snd_max;


### PR DESCRIPTION
When nginx use setsockopt ON_LINGER, the seq number of the RST packet is error.
    Use tcpdump to capture packets and you will find the problem.
    See:https://reviews.freebsd.org/D30036.