### PR TITLE
Add ff_stop_run to stop the poll loop

### DIFF
--- a/doc/F-Stack_API_Reference.md
+++ b/doc/F-Stack_API_Reference.md
@@ -49,6 +49,12 @@ However, it is  supported only before F-Stack is started.
   The ioctl() function manipulates the underlying device parameters of special files.
   more info see man ioctl.
 
+#### ff_stop_run
+
+	void ff_stop_run();
+
+  Stop the infinite poll loop started by `ff_run`.
+
 ### Network API
 
 #### ff_socket

--- a/lib/ff_api.h
+++ b/lib/ff_api.h
@@ -55,6 +55,8 @@ int ff_init(int argc, char * const argv[]);
 
 void ff_run(loop_func_t loop, void *arg);
 
+void ff_stop_run(void);
+
 /* POSIX-LIKE api begin */
 
 int ff_fcntl(int fd, int cmd, ...);

--- a/lib/ff_dpdk_if.h
+++ b/lib/ff_dpdk_if.h
@@ -39,6 +39,7 @@ struct loop_routine {
 int ff_dpdk_init(int argc, char **argv);
 int ff_dpdk_if_up(void);
 void ff_dpdk_run(loop_func_t loop, void *arg);
+void ff_dpdk_stop(void);
 
 struct ff_dpdk_if_context;
 struct ff_port_cfg;

--- a/lib/ff_init.c
+++ b/lib/ff_init.c
@@ -61,3 +61,9 @@ ff_run(loop_func_t loop, void *arg)
     ff_dpdk_run(loop, arg);
 }
 
+void
+ff_stop_run(void)
+{
+    ff_dpdk_stop();
+}
+


### PR DESCRIPTION
Support stop the infinite loop, as raised in the issue https://github.com/F-Stack/f-stack/issues/719.
There may exist some memory leaks if stop and restart the `ff_run` multiple times. It will be great if someone who are familiar with the memory allocation in f-stack can point this out. In the current test, the memory leak problem is minor with hundreds of stop and restart.
