### PR TITLE
Fix cplen calculation error in ff_hook_getsockname

### DIFF
--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -419,7 +419,7 @@ ff_hook_getsockname(int fd, struct sockaddr *name,
     SYSCALL(FF_SO_GETSOCKNAME, args);
 
     if (ret == 0) {
-        socklen_t cplen = *namelen ? *sh_namelen > *namelen
+        socklen_t cplen = *namelen < *sh_namelen ? *namelen
             : *sh_namelen;
         rte_memcpy(name, sh_name, cplen);
         *namelen = *sh_namelen;

--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -419,7 +419,7 @@ ff_hook_getsockname(int fd, struct sockaddr *name,
     SYSCALL(FF_SO_GETSOCKNAME, args);
 
     if (ret == 0) {
-        socklen_t cplen = *namelen < *sh_namelen ? *namelen
+        socklen_t cplen = *sh_namelen > *namelen ? *namelen
             : *sh_namelen;
         rte_memcpy(name, sh_name, cplen);
         *namelen = *sh_namelen;
@@ -475,7 +475,7 @@ ff_hook_getpeername(int fd, struct sockaddr *name,
     SYSCALL(FF_SO_GETPEERNAME, args);
 
     if (ret == 0) {
-        socklen_t cplen = *namelen ? *sh_namelen > *namelen
+        socklen_t cplen = *sh_namelen > *namelen ? *namelen
             : *sh_namelen;
         rte_memcpy(name, sh_name, cplen);
         *namelen = *sh_namelen;
@@ -794,7 +794,7 @@ ff_hook_recvfrom(int fd, void *buf, size_t len, int flags,
     if (ret >= 0) {
         rte_memcpy(buf, sh_buf, ret);
         if (from) {
-            socklen_t cplen = *fromlen ? *sh_fromlen > *fromlen
+            socklen_t cplen = *sh_fromlen > *fromlen ? *fromlen
                 : *sh_fromlen;
             rte_memcpy(from, sh_from, cplen);
             *fromlen = *sh_fromlen;


### PR DESCRIPTION
Dear authors,
Thank you for developing and maintaining f-stack. Currently I'm trying to use f-stack's LD_PRELOAD function in my research. However, I encounter several problems. While debugging, I found that the cplen seems to be wrong in ff_hook_getsockname.
By the way, now I'm still stuck at ff_hook_epoll_wait. It seems that ff_hook_epoll_wait can't get notified on the corresponding events when running a complicated application(possibly with several threads created with clone syscall). Any ideas?