### PR TITLE
Fix issue in Freebsd when building with GCC 14.1.0

### DIFF
--- a/freebsd/sys/cdefs.h
+++ b/freebsd/sys/cdefs.h
@@ -276,7 +276,7 @@
 #endif
 
 #if !defined(__cplusplus) && !__has_extension(c_atomic) && \
-    !__has_extension(cxx_atomic) && !__GNUC_PREREQ__(4, 7)
+    !__has_extension(cxx_atomic) && !__GNUC_PREREQ__(4, 9)
 /*
  * No native support for _Atomic(). Place object in structure to prevent
  * most forms of direct non-atomic access.

--- a/freebsd/sys/cdefs.h
+++ b/freebsd/sys/cdefs.h
@@ -276,7 +276,7 @@
 #endif
 
 #if !defined(__cplusplus) && !__has_extension(c_atomic) && \
-    !__has_extension(cxx_atomic)
+    !__has_extension(cxx_atomic) && !__GNUC_PREREQ__(4, 7)
 /*
  * No native support for _Atomic(). Place object in structure to prevent
  * most forms of direct non-atomic access.

--- a/freebsd/sys/stdatomic.h
+++ b/freebsd/sys/stdatomic.h
@@ -33,7 +33,7 @@
 #include <sys/cdefs.h>
 #include <sys/_types.h>
 
-#if __has_extension(c_atomic) || __has_extension(cxx_atomic)
+#if defined(__clang__) && (__has_extension(c_atomic) || __has_extension(cxx_atomic))
 #define	__CLANG_ATOMICS
 #elif __GNUC_PREREQ__(4, 7)
 #define	__GNUC_ATOMICS
@@ -85,6 +85,9 @@
 #if defined(__CLANG_ATOMICS)
 #define	ATOMIC_VAR_INIT(value)		(value)
 #define	atomic_init(obj, value)		__c11_atomic_init(obj, value)
+#elif defined(__GNUC_ATOMICS)
+#define	ATOMIC_VAR_INIT(value)		(value)
+#define	atomic_init(obj, value)		__atomic_init(obj, value)
 #else
 #define	ATOMIC_VAR_INIT(value)		{ .__val = (value) }
 #define	atomic_init(obj, value)		((void)((obj)->__val = (value)))
@@ -169,12 +172,9 @@ atomic_signal_fence(memory_order __order __unused)
 /* Atomics in kernelspace are always lock-free. */
 #define	atomic_is_lock_free(obj) \
 	((void)(obj), (_Bool)1)
-#elif defined(__CLANG_ATOMICS)
+#elif defined(__CLANG_ATOMICS) || defined(__GNUC_ATOMICS)
 #define	atomic_is_lock_free(obj) \
 	__atomic_is_lock_free(sizeof(*(obj)), obj)
-#elif defined(__GNUC_ATOMICS)
-#define	atomic_is_lock_free(obj) \
-	__atomic_is_lock_free(sizeof((obj)->__val), &(obj)->__val)
 #else
 #define	atomic_is_lock_free(obj) \
 	((void)(obj), sizeof((obj)->__val) <= sizeof(void *))
@@ -258,28 +258,28 @@ typedef _Atomic(__uintmax_t)		atomic_uintmax_t;
 #elif defined(__GNUC_ATOMICS)
 #define	atomic_compare_exchange_strong_explicit(object, expected,	\
     desired, success, failure)						\
-	__atomic_compare_exchange_n(&(object)->__val, expected,		\
+	__atomic_compare_exchange_n(object, expected,			\
 	    desired, 0, success, failure)
 #define	atomic_compare_exchange_weak_explicit(object, expected,		\
     desired, success, failure)						\
-	__atomic_compare_exchange_n(&(object)->__val, expected,		\
+	__atomic_compare_exchange_n(object, expected,			\
 	    desired, 1, success, failure)
 #define	atomic_exchange_explicit(object, desired, order)		\
-	__atomic_exchange_n(&(object)->__val, desired, order)
+	__atomic_exchange_n(object, desired, order)
 #define	atomic_fetch_add_explicit(object, operand, order)		\
-	__atomic_fetch_add(&(object)->__val, operand, order)
+	__atomic_fetch_add(object, operand, order)
 #define	atomic_fetch_and_explicit(object, operand, order)		\
-	__atomic_fetch_and(&(object)->__val, operand, order)
+	__atomic_fetch_and(object, operand, order)
 #define	atomic_fetch_or_explicit(object, operand, order)		\
-	__atomic_fetch_or(&(object)->__val, operand, order)
+	__atomic_fetch_or(object, operand, order)
 #define	atomic_fetch_sub_explicit(object, operand, order)		\
-	__atomic_fetch_sub(&(object)->__val, operand, order)
+	__atomic_fetch_sub(object, operand, order)
 #define	atomic_fetch_xor_explicit(object, operand, order)		\
-	__atomic_fetch_xor(&(object)->__val, operand, order)
+	__atomic_fetch_xor(object, operand, order)
 #define	atomic_load_explicit(object, order)				\
-	__atomic_load_n(&(object)->__val, order)
+	__atomic_load_n(object, order)
 #define	atomic_store_explicit(object, desired, order)			\
-	__atomic_store_n(&(object)->__val, desired, order)
+	__atomic_store_n(object, desired, order)
 #else
 #define	__atomic_apply_stride(object, operand) \
 	(((__typeof__((object)->__val))0) + (operand))

--- a/freebsd/sys/stdatomic.h
+++ b/freebsd/sys/stdatomic.h
@@ -35,7 +35,7 @@
 
 #if defined(__clang__) && (__has_extension(c_atomic) || __has_extension(cxx_atomic))
 #define	__CLANG_ATOMICS
-#elif __GNUC_PREREQ__(4, 7)
+#elif __GNUC_PREREQ__(4, 9)
 #define	__GNUC_ATOMICS
 #elif defined(__GNUC__)
 #define	__SYNC_ATOMICS


### PR DESCRIPTION
_Note: This is a PR directly to branch `1.21`._

Since GCC 14 now [implements](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60512) `__has_extension()` the build fails while building the F-stack `lib`.
The reason for the failure is the use of Clangs atomics APIs (`__c11_*`) which are only provided by Clang.

Fix the build to use C11 atomics when available in GCC by incorporating a fix already included in latest FreeBSD [stable/12](https://github.com/freebsd/freebsd-src/blame/stable/12/sys/sys/stdatomic.h#L174).
See https://reviews.freebsd.org/D16585 which enables C11 atomics when building with GCC >= 4.7.

Previously the non-native support for _Atomic() was used, placing objects in a structure to prevent direct non-atomic access,
but `_Atomic(T)` did not get defined for GCC-14.

**For reference**
See section `C family` regarding atomics in GCC-4.7 and has_extension() in GCC-14:
https://gcc.gnu.org/gcc-4.7/changes.html
https://gcc.gnu.org/gcc-14/changes.html