### PR TITLE
Update F-Stack_Quick_Start_Guide.md

### DIFF
--- a/doc/F-Stack_Quick_Start_Guide.md
+++ b/doc/F-Stack_Quick_Start_Guide.md
@@ -74,6 +74,7 @@ The mount point can be made permanent across reboots, by adding the following li
     cd /data/f-stack
     cd lib
     make
+    make install
 
 ### Compile Nginx
 


### PR DESCRIPTION
Although the title of this section is 'compile,' I still recommend adding an 'install' step. 

This is because I forgot to install while configuring the environment.