### PR TITLE
Close kernel epoll fd in ff_hook_close when using FF_KERNEL_EVENT

### DIFF
--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -1542,6 +1542,18 @@ ff_hook_close(int fd)
 
     SYSCALL(FF_SO_CLOSE, args);
 
+#ifdef FF_KERNEL_EVENT
+    if (ret == 0 && fstack_kernel_fd_map[fd]) {
+        int kernel_fd_ret = ff_linux_close(fstack_kernel_fd_map[fd]);
+        if (kernel_fd_ret < 0) {
+            ERR_LOG("fstack_kernel_fd_map[%d]=%d, ff_linux_close returns %d, errno=%d\n",
+                fd, fstack_kernel_fd_map[fd], kernel_fd_ret, errno);
+        } else {
+            fstack_kernel_fd_map[fd] = 0;
+        }
+    }
+#endif
+
     RETURN_NOFREE();
 }
 


### PR DESCRIPTION
Dear authors,
This commit fixes kernel fd leakage when using epoll in FF_KERNEL_EVENT. We had a problem with file descriptor exhaustion when running a library OS with F-Stack LD_PRELOAD. The kernel fd is created in ff_hook_epoll_create and saved into fstack_kernel_fd_map array. However, when calling close for f-stack fd, maybe we need to close the corresponding kernel fd as well.

Besides, currently the F-Stack LD_PRELOAD fd is larger than kernel maximum fd, which causes compatibility issues. For example, in lighttpd:
`force_assert(fd < ((int)FD_SETSIZE));`
Maybe we can use something else. For example, we use something like an array to record the fd created by F-Stack. To avoid overlap, we use a syscall like open() to occupy a fd created by Linux kernel. Then we can map the F-Stack fd to this fd and return this fd to user application. In this way, we can distinguish between the F-Stack fds and kernel fds.