### PR TITLE
Add POSIX Like functions for pthread_create and pthread_join

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -262,6 +262,7 @@ endif
 
 FF_HOST_SRCS+=              \
 	ff_host_interface.c \
+	ff_thread.c			\
 	ff_config.c         \
 	ff_ini_parser.c     \
 	ff_dpdk_if.c        \

--- a/lib/ff_api.h
+++ b/lib/ff_api.h
@@ -147,6 +147,10 @@ int ff_gettimeofday(struct timeval *tv, struct timezone *tz);
 int ff_dup(int oldfd);
 int ff_dup2(int oldfd, int newfd);
 
+int ff_pthread_create(pthread_t * thread, const pthread_attr_t * attr, 
+    void * (* start_routine) (void *), void * arg);
+int ff_pthread_join(pthread_t thread, void **retval);
+
 /* POSIX-LIKE api end */
 
 

--- a/lib/ff_api.symlist
+++ b/lib/ff_api.symlist
@@ -58,3 +58,5 @@ ff_zc_mbuf_get
 ff_zc_mbuf_write
 ff_zc_mbuf_read
 ff_get_traffic
+ff_pthread_create
+ff_pthread_join

--- a/lib/ff_thread.c
+++ b/lib/ff_thread.c
@@ -1,0 +1,51 @@
+#include <pthread.h>
+#include <errno.h>
+
+#include "ff_api.h"
+#include "ff_host_interface.h"
+
+extern __thread struct thread *pcurthread;
+
+struct thread_data {
+    void * (* start_routine) (void *);
+    void * arg;
+    struct thread *parent;
+};
+
+static void 
+ff_set_thread(struct thread *other) {
+    pcurthread = other;
+}
+
+static
+void* ff_start_routine(void * data) {
+    struct thread_data *p_data = (struct thread_data *) data;
+    
+    void * (* start_routine) (void *) = p_data->start_routine;
+    void *arg = p_data->arg;
+    ff_set_thread(p_data->parent);
+    ff_free(data);
+    start_routine(arg);
+    return NULL;
+}
+
+int
+ff_pthread_create(pthread_t *thread, const pthread_attr_t * attr, void * (* start_routine) (void *), void * arg) {
+    struct thread_data *data;
+    
+    data = ff_malloc(sizeof(struct thread_data));
+    if (!data) {
+        errno = ENOMEM;
+        return -ff_ENOMEM;
+    }
+
+    data->start_routine = start_routine;
+    data->arg = arg;
+    data->parent = pcurthread;
+    return pthread_create(thread, attr, ff_start_routine, data);
+}
+
+int 
+ff_pthread_join(pthread_t thread, void **retval) {
+    return pthread_join(thread, retval);
+}


### PR DESCRIPTION
Based on the comments from #430, I added the functions that are similar for POSIX pthread_create and pthread_join.