### PR TITLE
m_gethdr will call m_pkthdr_init also, so there is no need to initialize it again

### DIFF
--- a/lib/ff_veth.c
+++ b/lib/ff_veth.c
@@ -372,10 +372,6 @@ ff_mbuf_gethdr(void *pkt, uint16_t total, void *data,
         return NULL;
     }
 
-    if (m_pkthdr_init(m, M_NOWAIT) != 0) {
-        return NULL;
-    }
-
     m_extadd(m, data, len, ff_mbuf_ext_free, pkt, NULL, 0, EXT_DISPOSABLE);
 
     m->m_pkthdr.len = total;


### PR DESCRIPTION
m_gethdr use zone_mbuf.
In mbuf_init function

static void
mbuf_init(void *dummy)
{
    zone_mbuf = uma_zcreate(MBUF_MEM_NAME, MSIZE,
	    mb_ctor_mbuf, mb_dtor_mbuf, NULL, NULL,
	    MSIZE - 1, UMA_ZONE_CONTIG | UMA_ZONE_MAXBUCKET);
    ..
}
The mb_ctor_mbuf is uma constructor‌‌ callback