### PR TITLE
add ld_preload mode fcntl linux flags convert to freebsd

### DIFF
--- a/lib/ff_syscall_wrapper.c
+++ b/lib/ff_syscall_wrapper.c
@@ -371,7 +371,7 @@ freebsd2linux_fcntl(int cmd, int flags)
 
             if (flags & O_ASYNC) {
                 //clear linux O_ASYNC, set freebsd O_ASYNC.
-                *flags &= ~O_ASYNC;
+                flags &= ~O_ASYNC;
                 flags |= LINUX_O_ASYNC;
             }
 


### PR DESCRIPTION
When user call ff_fcntl, we should convert some cmd and flags from linux to freebsd mode.
when ff_cntl return, we should convert freebsd to linux mode also.