### PR TITLE
add tcp/udp loopback support, we can send packet through lo dev

### DIFF
--- a/freebsd/net/netisr.c
+++ b/freebsd/net/netisr.c
@@ -977,6 +977,14 @@ out:
 #endif
 }
 
+void inline
+ff_swi_net_excute(void)
+{
+	struct netisr_workstream *nwsp = DPCPU_ID_PTR(0, nws);
+
+	return swi_net((void*)nwsp);
+}
+
 static int
 netisr_queue_workstream(struct netisr_workstream *nwsp, u_int proto,
     struct netisr_work *npwp, struct mbuf *m, int *dosignalp)

--- a/freebsd/netinet/in_pcb.c
+++ b/freebsd/netinet/in_pcb.c
@@ -1512,6 +1512,11 @@ in_pcbconnect_setup(struct inpcb *inp, struct sockaddr *nam,
 			    cred);
 			if (error)
 				return (error);
+			/* Note:
+			 * LOOPBACK not support rss.
+			 */
+			if ((ifp->if_softc == NULL) && (ifp->if_flags & IFF_LOOPBACK))
+				break;
 			rss = ff_rss_check(ifp->if_softc, faddr.s_addr, laddr.s_addr,
 			    fport, lport);
 			if (rss) {

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -51,6 +51,9 @@ FF_INET6=1
 FF_TCPHPTS=1
 FF_EXTRA_TCP_STACKS=1
 
+# TCP/UDP loopback.
+#FF_LOOPBACK_SUPPORT=1
+
 include ${TOPDIR}/mk/kern.pre.mk
 
 ifneq ($(shell pkg-config --exists libdpdk && echo 0),0)
@@ -141,6 +144,11 @@ endif
 ifdef FF_IPSEC
 HOST_CFLAGS+= -DIPSEC
 CFLAGS+= -DIPSEC
+endif
+
+ifdef FF_LOOPBACK_SUPPORT
+HOST_CFLAGS+= -DFF_LOOPBACK_SUPPORT
+CFLAGS+= -DFF_LOOPBACK_SUPPORT
 endif
 
 HOST_C= ${CC} -c $(HOST_CFLAGS) ${HOST_INCLUDES} ${WERROR} ${PROF} $<

--- a/lib/ff_api.symlist
+++ b/lib/ff_api.symlist
@@ -63,3 +63,4 @@ ff_pthread_create
 ff_pthread_join
 pcurthread
 ff_dpdk_raw_packet_send
+ff_swi_net_excute

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -2167,7 +2167,9 @@ main_loop(void *arg)
         }
 
         process_msg_ring(qconf->proc_id, pkts_burst);
-
+#ifdef FF_LOOPBACK_SUPPORT
+        ff_swi_net_excute();
+#endif
         div_tsc = rte_rdtsc();
 
         if (likely(lr->loop != NULL && (!idle || cur_tsc - usch_tsc >= drain_tsc))) {

--- a/lib/ff_host_interface.h
+++ b/lib/ff_host_interface.h
@@ -78,5 +78,7 @@ int ff_in_pcbladdr(uint16_t family, void *faddr, uint16_t fport, void *laddr);
 int ff_rss_check(void *softc, uint32_t saddr, uint32_t daddr,
     uint16_t sport, uint16_t dport);
 
+void ff_swi_net_excute(void);
+
 #endif
 


### PR DESCRIPTION
In LD_PRELOAD mode, when we connect 127.0.0.1 or other local addr(dev addr), we call looutput function finally，so we should call swi_net re-enter this packet into the protocol stack entry.