### PR TITLE
add epoll polling mode, improve latency performance in RTT mode

### DIFF
--- a/adapter/syscall/Makefile
+++ b/adapter/syscall/Makefile
@@ -17,6 +17,10 @@ endif
 # If disable it, one socket can use in all threads.
 #FF_THREAD_SOCKET=1
 
+# Epoll polling mode, now only support freebsd socket, not support FF_KERNEL_EVENT.  
+# If disable it, epoll use sem_wait.
+#FF_PRELOAD_POLLING_MODE=1
+
 # If enable FF_KERNEL_EVENT, epoll_create/epoll_clt/epoll_wait always call f-stack and system API at the same time.
 # Use for some scenarios similar to Nginx.
 #FF_KERNEL_EVENT=1
@@ -39,6 +43,10 @@ endif
 
 ifdef FF_MULTI_SC
 	CFLAGS+= -DFF_MULTI_SC
+endif
+
+ifdef FF_PRELOAD_POLLING_MODE
+	CFLAGS+= -DFF_PRELOAD_POLLING_MODE
 endif
 
 CFLAGS += -fPIC -Wall -Werror $(shell $(PKGCONF) --cflags libdpdk)

--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -1827,7 +1827,7 @@ retry:
         else  {
             if (timeout > 0) {
                 clock_gettime(CLOCK_MONOTONIC_COARSE, &t_n);
-                now_time_ms = t_n * 1000 + t_n / 1000000;
+                now_time_ms = t_n.tv_sec * 1000 + t_n.tv_nsec / 1000000;
 
                 if (now_time_ms >= end_time_ms) {
                     goto epoll_exit;
@@ -1836,7 +1836,7 @@ retry:
 
             goto retry;
         }
-    }while(true);
+    } while(true);
 
 epoll_exit:
     if (likely(ret > 0)) {

--- a/adapter/syscall/ff_socket_ops.c
+++ b/adapter/syscall/ff_socket_ops.c
@@ -485,7 +485,6 @@ ff_handle_socket_ops(struct ff_so_context *sc)
 #ifdef FF_PRELOAD_POLLING_MODE
         if (sem_flag == 1 && sc->ops == FF_SO_EPOLL_WAIT) {
             sc->status = FF_SC_REP;
-            sem_flag = 0;
         }
 #else
         if (sem_flag == 1) {

--- a/adapter/syscall/ff_socket_ops.c
+++ b/adapter/syscall/ff_socket_ops.c
@@ -308,9 +308,18 @@ ff_sys_epoll_wait(struct ff_epoll_wait_args *args)
 
 #ifdef FF_PRELOAD_POLLING_MODE
     /*
-     * We set sem_flag 1, when set sc->status = FF_SC_REP, set sem_flag 0.
+     * If an event is generated or error occurs, user app epoll_wait return imme.
      */
-    sem_flag = 1;
+    if (ret != 0) {
+        sem_flag = 1;
+    } else {
+        if (args->timeout < 0) {
+            /* -1 : Block user app until an event or error occurs. */
+            sem_flag = 0;
+        } else {
+            sem_flag = 1;
+        }
+    }
 #else
     /*
      * If timeout is 0, and no event triggered,


### PR DESCRIPTION
NOTICE:In the following data, sem_wait block mode, when the timeout > 0 or timeout < 0, the RTT latency performance is poor. After reviewing the code implementation, I found the main issue lies in the flawed sem_flag logic within the ff_sys_epoll_wait function. This defect causes both sem_wait and sem_timedwait to essentially fail their intended functions, which instead of helping, is actually degrading system performance. I will address this by submitting a code fix in the next commit to correct the semaphore handling logic.

Add epoll polling mode, improve latency performance in RTT mode.
The test results after modification are as follows：
i5-12400 4.4Ghz   TSC 2.5Ghz
RTT测试
epoll_wait(polling mode)
timeout = 0
    32字节     7822时钟周期    3.128us
    1400字节 9684时钟周期    3.873us
timeout = -1
    32字节     7398时钟周期    2.959us
    1400字节 9478时钟周期    3.791us
timeout = 1000
    32字节     7395时钟周期    2.958us
    1400字节 9524时钟周期    3.809us
	
epoll_wait(sem_wait block mode)
timeout = 0
    32字节     12674时钟周期    5.069us
    1400字节 15000时钟周期    6us
timeout = -1
    32字节     18764时钟周期    7.505us
    1400字节 20408时钟周期    8.163us
timeout = 1000
    32字节     17474时钟周期    6.989us
    1400字节 20113时钟周期    8.045us