### PR TITLE
add __recv_chk/__read_chk/__recvfrom_chk

### DIFF
--- a/adapter/syscall/ff_hook_syscall.h
+++ b/adapter/syscall/ff_hook_syscall.h
@@ -3,6 +3,10 @@
 
 #undef FF_SYSCALL_DECL
 #define FF_SYSCALL_DECL(ret, fn, args) extern ret ff_hook_##fn args
+FF_SYSCALL_DECL(ssize_t, __recv_chk, (int, void *, size_t, size_t, int));
+FF_SYSCALL_DECL(ssize_t, __read_chk, (int, void *, size_t, size_t));
+FF_SYSCALL_DECL(ssize_t, __recvfrom_chk, (int, void *, size_t, size_t, int,
+    struct sockaddr *, socklen_t *));
 #include <ff_declare_syscalls.h>
 
 extern int kqueue(void);


### PR DESCRIPTION
When compiling code with a higher version of GCC, some uses of recv are translated into __recv_chk.
The same applies to __read_chk and __recvfrom_chk.