### PR TITLE
add fork support, like linux kernel, every process has one freebsd struct thread

### DIFF
--- a/adapter/syscall/Makefile
+++ b/adapter/syscall/Makefile
@@ -25,6 +25,10 @@ endif
 # Use for some scenarios similar to Nginx.
 #FF_KERNEL_EVENT=1
 
+# If enable FF_USE_THREAD_STRUCT_HANDLE, every ff_so_context has one struct thread  handle in fstack, fork will be supported
+# like linux kernel.
+#FF_USE_THREAD_STRUCT_HANDLE=1
+
 PKGCONF ?= pkg-config
 
 ifndef DEBUG
@@ -47,6 +51,10 @@ endif
 
 ifdef FF_PRELOAD_POLLING_MODE
 	CFLAGS+= -DFF_PRELOAD_POLLING_MODE
+endif
+
+ifdef FF_USE_THREAD_STRUCT_HANDLE
+	CFLAGS+= -DFF_USE_THREAD_STRUCT_HANDLE
 endif
 
 CFLAGS += -fPIC -Wall -Werror $(shell $(PKGCONF) --cflags libdpdk)

--- a/adapter/syscall/ff_adapter.h
+++ b/adapter/syscall/ff_adapter.h
@@ -10,6 +10,8 @@
 int ff_adapter_init();
 //int __attribute__((constructor)) ff_adapter_init(int argc, char * const argv[]);
 
+int ff_adapter_child_process_init(void);
+
 void alarm_event_sem();
 
 /*-

--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -2138,12 +2138,38 @@ ff_hook_fork(void)
             current_worker_id++;
             ERR_LOG("parent process, current_worker_id++:%d\n", current_worker_id);
 #endif
+#ifdef FF_USE_THREAD_STRUCT_HANDLE
+            sc->forking = 1;
+            /* Loop until child fork done. */
+            while (sc->forking);
+#endif
         }
         else if (pid == 0) {
             ERR_LOG("chilid process, sc:%p, sc->refcount:%d, ff_so_zone:%p\n",
                 sc, sc->refcount, ff_so_zone);
 #ifdef FF_MULTI_SC
             ERR_LOG("chilid process, current_worker_id:%d\n", current_worker_id);
+#endif
+#ifdef FF_USE_THREAD_STRUCT_HANDLE
+            struct ff_so_context *parent_sc = sc;
+
+            /* Child process attach new sc */
+            ff_adapter_child_process_init();
+    
+            /* 
+             * The fork system call duplicates the file 
+             * descriptors that were open in the parent process 
+             */
+            DEFINE_REQ_ARGS(fork);
+            args->parent_thread_handle = parent_sc->ff_thread_handle;
+            /* Output value */
+            args->child_thread_handle = NULL;
+            SYSCALL(FF_SO_FORK, args);
+            if (ret == 0) {
+                sc->ff_thread_handle = args->child_thread_handle;
+            }
+
+            parent_sc->forking = 0;
 #endif
         }
 
@@ -2442,6 +2468,16 @@ thread_destructor(void *sc)
     }
 }
 
+static inline int
+ff_application_exit(struct ff_so_context *sc)
+{
+    DEFINE_REQ_ARGS(exit_application);
+    args->sc = sc;
+    SYSCALL(FF_SO_EXIT_APPLICATION, args);
+
+    return ret;
+}
+
 void __attribute__((destructor))
 ff_adapter_exit()
 {
@@ -2455,13 +2491,19 @@ ff_adapter_exit()
         for (i = 0; i < worker_id; i++) {
             ERR_LOG("pthread self tid:%lu, detach sc:%p\n", pthread_self(), scs[i].sc);
             ff_so_zone = ff_so_zones[i];
-            ff_detach_so_context(scs[i].sc);
+#ifdef FF_USE_THREAD_STRUCT_HANDLE
+            ff_application_exit(scs[i].sc);
+#endif
+            ff_detach_so_context(scs[i].sc);            
         }
     } else
 #endif
     {
         ERR_LOG("pthread self tid:%lu, detach sc:%p\n", pthread_self(), sc);
-        ff_detach_so_context(sc);
+#ifdef FF_USE_THREAD_STRUCT_HANDLE
+        ff_application_exit(sc);
+#endif
+        ff_detach_so_context(sc);        
         sc = NULL;
     }
 #endif
@@ -2618,7 +2660,36 @@ ff_adapter_init()
 
     rte_spinlock_unlock(&worker_id_lock);
 
+#ifdef FF_USE_THREAD_STRUCT_HANDLE
+    /* 
+     * Request to fstack, alloc sc->ff_thread_handle 
+     * Every appliaction 
+     */
+    {
+        DEFINE_REQ_ARGS(register_application);
+        args->sc = sc;
+        SYSCALL(FF_SO_REGISTER_APPLICATION, args);
+        if (ret < 0) {
+            return -1;
+        }
+    }
+#endif
+
     ERR_LOG("ff_adapter_init success, sc:%p, status:%d, ops:%d\n", sc, sc->status, sc->ops);
+
+    return 0;
+}
+
+int
+ff_adapter_child_process_init(void)
+{
+    sc = ff_attach_so_context(0);
+    if (sc == NULL) {
+        ERR_LOG("ff_attach_so_context failed\n");
+        return -1;
+    }
+
+    ERR_LOG("ff_adapter_child_process_init success, sc:%p, status:%d, ops:%d\n", sc, sc->status, sc->ops);
 
     return 0;
 }

--- a/adapter/syscall/ff_so_zone.c
+++ b/adapter/syscall/ff_so_zone.c
@@ -95,6 +95,7 @@ ff_create_so_memzone()
                 sc->status = FF_SC_IDLE;
                 sc->idx = i;
                 sc->refcount = 0;
+                sc->ff_thread_handle = NULL;
                 //so_zone_tmp->inuse[i] = 0;
 
                 if (sem_init(&sc->wait_sem, 1, 0) == -1) {

--- a/adapter/syscall/ff_socket_ops.h
+++ b/adapter/syscall/ff_socket_ops.h
@@ -64,6 +64,8 @@ enum FF_SOCKET_OPS {
     FF_SO_KQUEUE,
     FF_SO_KEVENT,
     FF_SO_FORK, // 29
+    FF_SO_REGISTER_APPLICATION,
+    FF_SO_EXIT_APPLICATION,
 };
 
 enum FF_SO_CONTEXT_STATUS {
@@ -110,6 +112,8 @@ struct ff_so_context {
     /* CACHE LINE 1 */
     /* listen fd, refcount.. */
     int refcount;
+    void *ff_thread_handle;
+    volatile int forking;
 } __attribute__((aligned(RTE_CACHE_LINE_SIZE)));
 
 extern __FF_THREAD struct ff_socket_ops_zone *ff_so_zone;

--- a/adapter/syscall/ff_sysproto.h
+++ b/adapter/syscall/ff_sysproto.h
@@ -191,7 +191,16 @@ struct ff_kevent_args {
 };
 
 struct ff_fork_args {
+    void *parent_thread_handle;
+    void *child_thread_handle;
+};
 
+struct ff_register_application_args {
+    struct ff_so_context *sc;
+};
+
+struct ff_exit_application_args {
+    struct ff_so_context *sc;
 };
 
 #endif

--- a/freebsd/sys/filedesc.h
+++ b/freebsd/sys/filedesc.h
@@ -255,6 +255,7 @@ int	fdcopy_remapped(struct filedesc *fdp, const int *fds, size_t nfds,
 void	fdinstall_remapped(struct thread *td, struct filedesc *fdp);
 void	fdunshare(struct thread *td);
 void	fdescfree(struct thread *td);
+void	fdescfree_adapt_use(struct thread *td);
 void	fdescfree_remapped(struct filedesc *fdp);
 int	fdlastfile(struct filedesc *fdp);
 int	fdlastfile_single(struct filedesc *fdp);

--- a/lib/ff_api.h
+++ b/lib/ff_api.h
@@ -356,6 +356,18 @@ int ff_zc_mbuf_write(struct ff_zc_mbuf *m, const char *data, int len);
  */
 int ff_zc_mbuf_read(struct ff_zc_mbuf *m, const char *data, int len);
 
+/*
+ * Create user thread context for LD_PRELOAD mode.
+ * It saved in ff_so_context.
+ */
+void *ff_adapt_user_thread_add(void *parent);
+
+void ff_adapt_user_thread_exit(void *td);
+
+void *ff_switch_curthread(void *new_curthread);
+
+void ff_restore_curthread(void *old_curthread);
+
 /* ZERO COPY API end */
 
 #ifdef __cplusplus

--- a/lib/ff_api.symlist
+++ b/lib/ff_api.symlist
@@ -65,3 +65,7 @@ ff_pthread_join
 pcurthread
 ff_dpdk_raw_packet_send
 ff_swi_net_excute
+ff_adapt_user_thread_add
+ff_adapt_user_thread_exit
+ff_switch_curthread
+ff_restore_curthread

--- a/lib/ff_glue.c
+++ b/lib/ff_glue.c
@@ -746,6 +746,14 @@ lim_alloc()
     return (limp);
 }
 
+void
+lim_free(struct plimit *limp)
+{
+
+	if (refcount_release(&limp->pl_refcnt))
+		free((void *)limp, M_PLIMIT);
+}
+
 struct plimit *
 lim_hold(struct plimit *limp)
 {


### PR DESCRIPTION
The current fork implementation has an issue: after creating a socket and invoking fork, both the parent and child processes call close. When the parent process closes the socket, it is released immediately. Subsequently, when the child process attempts to close it, the file descriptor (fd) no longer exists. This behavior differs significantly from Linux, which can lead to various problems. In a true Linux implementation:

Child processes ‌inherit‌ open file descriptors from the parent upon fork, meaning the reference count of the file is incremented.
Each process in Linux corresponds to a task_struct.

The purpose of this commit is to ‌simulate Linux's behavior‌ by addressing these two aspects.

The partial reason has been explained in my CSDN blog：
https://blog.csdn.net/weixin_41607301/article/details/146396412?spm=1001.2014.3001.5502