### PR TITLE
修改real_if_indextoname返回值及类型转换

### DIFF
--- a/dpdk/drivers/net/mlx5/linux/mlx5_ethdev_os.c
+++ b/dpdk/drivers/net/mlx5/linux/mlx5_ethdev_os.c
@@ -1046,7 +1046,7 @@ mlx5_sysfs_check_switch_info(bool device_dir,
  * @return
  *   0 on success, a negative errno value otherwise and rte_errno is set.
  */
-static int (*real_if_indextoname)(unsigned int, char *);
+static char *(*real_if_indextoname)(unsigned int, char *) = NULL;
 int
 mlx5_sysfs_switch_info(unsigned int ifindex, struct mlx5_switch_info *info)
 {
@@ -1069,7 +1069,7 @@ mlx5_sysfs_switch_info(unsigned int ifindex, struct mlx5_switch_info *info)
 
 	// for ff tools
 	if (!real_if_indextoname) {
-		real_if_indextoname = dlsym(RTLD_NEXT, "if_indextoname");
+		real_if_indextoname = __extension__ (char *(*)(unsigned int, char *))dlsym(RTLD_NEXT, "if_indextoname");
 		if (!real_if_indextoname) {
 			rte_errno = errno;
 			return -rte_errno;


### PR DESCRIPTION
开启MLX5_DEBUG选项，出现编译错误。
修改real_if_indextoname返回值及类型转换