### PR TITLE
f-stack socket options 

### DIFF
--- a/app/nginx-1.25.2/src/event/ngx_event_connect.c
+++ b/app/nginx-1.25.2/src/event/ngx_event_connect.c
@@ -386,31 +386,22 @@ ngx_event_connect_set_transparent(ngx_peer_connection_t *pc, ngx_socket_t s)
 
     case AF_INET:
 
-#if defined(NGX_HAVE_FSTACK)
-        /****
-        FreeBSD define IP_BINDANY in freebsd/netinet/in.h
-        Fstack should only support IP_BINDANY.
-        ****/
-        if(is_fstack_fd(s)){
-            optname = IP_BINDANY;
-        } else {
-            optname = IP_TRANSPARENT;
-        }
-
-        if (setsockopt(s, IPPROTO_IP, optname,
-                       (const void *) &value, sizeof(int)) == -1)
-        {
-            ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
-                   "setsockopt(IP_BINDANY/IP_TRANSPARENT) failed");
-            return NGX_ERROR;
-        }
-
-#elif defined(IP_TRANSPARENT)
+#if defined(IP_TRANSPARENT)
         if (setsockopt(s, IPPROTO_IP, IP_TRANSPARENT,
                        (const void *) &value, sizeof(int)) == -1)
         {
             ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
             "setsockopt(IP_TRANSPARENT) failed");
+            return NGX_ERROR;
+        }
+
+#elif defined(IP_BINDANY)
+
+        if (setsockopt(s, IPPROTO_IP, IP_BINDANY,
+                       (const void *) &value, sizeof(int)) == -1)
+        {
+            ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
+                          "setsockopt(IP_BINDANY) failed");
             return NGX_ERROR;
         }
 

--- a/app/nginx-1.28.0/src/event/ngx_event_connect.c
+++ b/app/nginx-1.28.0/src/event/ngx_event_connect.c
@@ -386,31 +386,22 @@ ngx_event_connect_set_transparent(ngx_peer_connection_t *pc, ngx_socket_t s)
 
     case AF_INET:
 
-#if defined(NGX_HAVE_FSTACK)
-        /****
-        FreeBSD define IP_BINDANY in freebsd/netinet/in.h
-        Fstack should only support IP_BINDANY.
-        ****/
-        if(is_fstack_fd(s)){
-            optname = IP_BINDANY;
-        } else {
-            optname = IP_TRANSPARENT;
-        }
-
-        if (setsockopt(s, IPPROTO_IP, optname,
-                       (const void *) &value, sizeof(int)) == -1)
-        {
-            ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
-                   "setsockopt(IP_BINDANY/IP_TRANSPARENT) failed");
-            return NGX_ERROR;
-        }
-
-#elif defined(IP_TRANSPARENT)
+#if defined(IP_TRANSPARENT)
         if (setsockopt(s, IPPROTO_IP, IP_TRANSPARENT,
                        (const void *) &value, sizeof(int)) == -1)
         {
             ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
             "setsockopt(IP_TRANSPARENT) failed");
+            return NGX_ERROR;
+        }
+
+#elif defined(IP_BINDANY)
+
+        if (setsockopt(s, IPPROTO_IP, IP_BINDANY,
+                       (const void *) &value, sizeof(int)) == -1)
+        {
+            ngx_log_error(NGX_LOG_ALERT, pc->log, ngx_socket_errno,
+                          "setsockopt(IP_BINDANY) failed");
             return NGX_ERROR;
         }
 

--- a/lib/ff_syscall_wrapper.c
+++ b/lib/ff_syscall_wrapper.c
@@ -101,6 +101,7 @@
 
 #define LINUX_IPV6_V6ONLY           26
 #define LINUX_IPV6_RECVPKTINFO      49
+#define LINUX_IPV6_PKTINFO          50
 #define LINUX_IPV6_TRANSPARENT      75
 
 #define LINUX_TCP_NODELAY     1
@@ -807,6 +808,17 @@ linux2freebsd_cmsg(const struct linux_msghdr *linux_msg, struct msghdr *freebsd_
                         break;
                 }
 
+                break;
+            case IPPROTO_IPV6:
+                switch (linux_cmsg->cmsg_type) {
+                    case LINUX_IPV6_PKTINFO:
+                        freebsd_cmsg->cmsg_type = IPV6_PKTINFO;
+                        *freebsd_optval = *(struct in6_pktinfo *)linux_optval;
+                        break;
+                    default:
+                        memcpy(freebsd_optval, linux_optval, linux_cmsg->cmsg_len - sizeof(struct linux_cmsghdr));
+                        break;
+                }
                 break;
             default:
                 memcpy(freebsd_optval, linux_optval, linux_cmsg->cmsg_len - sizeof(struct linux_cmsghdr));


### PR DESCRIPTION
f-stack supports the socket options IP_TRANSPARENT and IPV6_TRANSPARENT. Nginx does not require additional checks, and the translation for IPV6_PKTINFO has been added.