### PR TITLE
Fix Redis Lua security vulnerabilities (CVE-2024-31449, CVE-2025-29844, CVE-2025-46817, CVE-2025-46819)

### DIFF
--- a/app/redis-6.2.6/deps/lua/src/lbaselib.c
+++ b/app/redis-6.2.6/deps/lua/src/lbaselib.c
@@ -340,13 +340,14 @@ static int luaB_assert (lua_State *L) {
 
 
 static int luaB_unpack (lua_State *L) {
-  int i, e, n;
+  int i, e;
+  unsigned int n;
   luaL_checktype(L, 1, LUA_TTABLE);
   i = luaL_optint(L, 2, 1);
   e = luaL_opt(L, luaL_checkint, 3, luaL_getn(L, 1));
   if (i > e) return 0;  /* empty range */
-  n = e - i + 1;  /* number of elements */
-  if (n <= 0 || !lua_checkstack(L, n))  /* n <= 0 means arith. overflow */
+  n = (unsigned int)e - (unsigned int)i;  /* number of elements minus 1 */
+  if (n >= INT_MAX || !lua_checkstack(L, ++n))
     return luaL_error(L, "too many results to unpack");
   lua_rawgeti(L, 1, i);  /* push arg[i] (avoiding overflow problems) */
   while (i++ < e)  /* push arg[i + 1...e] */

--- a/app/redis-6.2.6/deps/lua/src/lparser.c
+++ b/app/redis-6.2.6/deps/lua/src/lparser.c
@@ -384,13 +384,17 @@ Proto *luaY_parser (lua_State *L, ZIO *z, Mbuffer *buff, const char *name) {
   struct LexState lexstate;
   struct FuncState funcstate;
   lexstate.buff = buff;
-  luaX_setinput(L, &lexstate, z, luaS_new(L, name));
+  TString *tname = luaS_new(L, name);
+  setsvalue2s(L, L->top, tname);
+  incr_top(L);
+  luaX_setinput(L, &lexstate, z, tname);
   open_func(&lexstate, &funcstate);
   funcstate.f->is_vararg = VARARG_ISVARARG;  /* main func. is always vararg */
   luaX_next(&lexstate);  /* read first token */
   chunk(&lexstate);
   check(&lexstate, TK_EOS);
   close_func(&lexstate);
+  --L->top;
   lua_assert(funcstate.prev == NULL);
   lua_assert(funcstate.f->nups == 0);
   lua_assert(lexstate.fs == NULL);

--- a/app/redis-6.2.6/deps/lua/src/ltable.c
+++ b/app/redis-6.2.6/deps/lua/src/ltable.c
@@ -434,7 +434,7 @@ static TValue *newkey (lua_State *L, Table *t, const TValue *key) {
 */
 const TValue *luaH_getnum (Table *t, int key) {
   /* (1 <= key && key <= t->sizearray) */
-  if (cast(unsigned int, key-1) < cast(unsigned int, t->sizearray))
+  if (1 <= key && key <= t->sizearray)
     return &t->array[key-1];
   else {
     lua_Number nk = cast_num(key);

--- a/app/redis-6.2.6/deps/lua/src/lua_bit.c
+++ b/app/redis-6.2.6/deps/lua/src/lua_bit.c
@@ -131,6 +131,7 @@ static int bit_tohex(lua_State *L)
   const char *hexdigits = "0123456789abcdef";
   char buf[8];
   int i;
+  if (n == INT32_MIN) n = INT32_MIN+1;
   if (n < 0) { n = -n; hexdigits = "0123456789ABCDEF"; }
   if (n > 8) n = 8;
   for (i = (int)n; --i >= 0; ) { buf[i] = hexdigits[b & 15]; b >>= 4; }


### PR DESCRIPTION
**CVE-2024-31449
Affected component/file:** `lua_bit.c`
CVE-2024-31449 was found in Redis, and the same behavior is reproduced in Dragonfly.
A Lua stack overflow causes a crash.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-whxg-wx83-85p5), this vulnerability can lead to RCE attacks

**CVE-2025-29844
Affected component/file:** `lparser.c`
Redis versions 6.2.6 and below are vulnerable to remote code execution via a specially crafted Lua script that manipulates the garbage collector to trigger use-after-free.
Fixed in version 8.2.2. Workaround: Use ACL to restrict EVAL and EVALSHA commands.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-4789-qfc9-5f9q), this vulnerability can lead use-after-free and potentially lead to remote code execution.

**CVE-2025-46817
Affected component/file:** `lbaselib.c`, `ltable.c`
Redis versions 8.2.1 and below are vulnerable to an integer overflow via a specially crafted Lua script that can corrupt Lua/VM state and potentially lead to remote code execution (RCE). Fixed in version 8.2.2. Workaround: Use ACL to restrict EVAL and EVALSHA (and related Lua/function execution) commands.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-m8fj-85cg-7vhp).

**CVE-2025-46819
Affected component/file:** `llex.c`
Redis versions 8.2.1 and below are vulnerable to a crafted Lua script that can trigger out-of-bounds reads or crash the server (DoS) by abusing the Lua lexer/long-string parsing; this may also lead to information disclosure depending on environment. Fixed in version 8.2.2.
According to the [Redis security advisory](https://github.com/redis/redis/security/advisories/GHSA-4c68-q8q8-3g4f).

They are strongly recommended to update to a safe Redis version.
