### PR TITLE
fix setsockopt issue

### DIFF
--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -642,6 +642,8 @@ ff_hook_setsockopt(int fd, int level, int optname,
                 RETURN_ERROR_NOFREE(ENOMEM);
             }
         }
+
+        rte_memcpy(sh_optval, optval, optlen);
     }
 
     args->fd = fd;


### PR DESCRIPTION
The user's parameter passed to setsockopt is not actually set to sh_optval