### PR TITLE
Add enhanced packet dispatcher API with VLAN context support

### DIFF
--- a/lib/ff_api.h
+++ b/lib/ff_api.h
@@ -219,8 +219,47 @@ int ff_route_ctl(enum FF_ROUTE_CTL req, enum FF_ROUTE_FLAG flag,
 typedef int (*dispatch_func_t)(void *data, uint16_t *len,
     uint16_t queue_id, uint16_t nb_queues);
 
+/*
+ * Packet dispatcher context structure.
+ * Contains additional context information for packet dispatching.
+ */
+struct ff_dispatcher_context {
+  struct {
+      uint8_t stripped;
+      uint16_t vlan_tci;  /**< Priority (3) + CFI (1) + Identifier Code (12) */
+  } vlan;
+};
+
+/*
+ * Enhanced packet dispatch callback function with context.
+ * Implemented by user.
+ *
+ * @param data
+ *   The data pointer of this packet.
+ * @param len
+ *   The length of this packet.
+ * @param queue_id
+ *   Current queue of this packet.
+ * @param nb_queues
+ *   Number of queues to be dispatched.
+ * @param context
+ *   Additional context information for packet dispatching.
+ *
+ * @return 0 to (nb_queues - 1)
+ *   The queue id that the packet will be dispatched to.
+ * @return FF_DISPATCH_ERROR (-1)
+ *   Error occurs or packet is handled by user, packet will be freed.
+ * @return FF_DISPATCH_RESPONSE (-2)
+ *   Packet is handled by user, packet will be responsed.
+ */
+typedef int (*dispatch_func_context_t)(void *data, uint16_t *len,
+    uint16_t queue_id, uint16_t nb_queues, struct ff_dispatcher_context context);
+
 /* regist a packet dispath function */
 void ff_regist_packet_dispatcher(dispatch_func_t func);
+
+/* Register a packet dispatch function with context support */
+void ff_regist_packet_dispatcher_context(dispatch_func_context_t func);
 
 /*
  * RAW packet send direty with DPDK by user APP.


### PR DESCRIPTION
This PR add a new API `ff_regist_packet_dispatcher_context()` that extends the existing packet dispatching functionality by providing additional context information to callback functions.

Primarily solves the issue that the dispatcher cannot access VLAN header when asynchronously sending packets with `vlan_strip` enabled.