### PR TITLE
fix some sendmsg and recvmsg issue

### DIFF
--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -1132,10 +1132,6 @@ iovec_share2local(struct iovec *share,
             count = total;
         }
 
-        share[i].iov_base =
-            (char *)share[i].iov_base - count;
-        share[i].iov_len += count;
-
         if (copy) {
             rte_memcpy(local[i].iov_base,
                 share[i].iov_base, count);
@@ -1672,12 +1668,6 @@ ff_hook_sendmsg(int fd, const struct msghdr *msg, int flags)
     args->flags = flags;
 
     SYSCALL(FF_SO_SENDMSG, args);
-
-    if (ret > 0) {
-        iovec_share2local(sh_msg->msg_iov,
-            msg->msg_iov, msg->msg_iovlen,
-            ret, 0);
-    }
 
     msghdr_share_free(sh_msg);
 


### PR DESCRIPTION
For the sendmsg function, the msg parameter is an input-only parameter, not an input-output parameter. The interface does not modify the user-provided msg structure, and no conversion is required after the send operation completes.

For the iovec_share2local interface, regarding functions like readv and recvmsg, the FreeBSD-side interfaces do not modify the iov_len of the iovec structures. Since we have already invoked msghdr_share_alloc, which synchronizes the variable sizes of the iovec, there is no need to offset the iov_base