### PR TITLE
Fix infinite loop when restarting the secondary process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         apt-get -qq update
         apt-get -qq install -y libssl-dev ninja-build
         cd dpdk
-        meson -Denable_kmods=true build
+        meson setup build -Dkernel_dir=/lib/modules/6.8.0-64-generic/build
         ninja -C build install
     - name: Compile f-stack
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,8 @@ jobs:
       run: |
         apt-get -qq update
         apt-get -qq install -y libssl-dev ninja-build
-        # using pre-built dpdk inside the container
-        cp -r /root/dpdk/build dpdk/build
         cd dpdk
+        meson -Denable_kmods=true build
         ninja -C build install
     - name: Compile f-stack
       run: |

--- a/dpdk/lib/timer/rte_timer.c
+++ b/dpdk/lib/timer/rte_timer.c
@@ -213,6 +213,20 @@ rte_timer_init(struct rte_timer *tim)
 	rte_atomic_store_explicit(&tim->status.u32, status.u32, rte_memory_order_relaxed);
 }
 
+int
+rte_timer_meta_init(void)
+{
+    struct rte_timer_data *timer_data;
+    struct priv_timer *pt;
+    unsigned lcore_id = rte_lcore_id();
+
+    TIMER_DATA_VALID_GET_OR_ERR_RET(default_data_id, timer_data, -EINVAL);
+    pt = &timer_data->priv_timer[lcore_id];
+    memset(pt, 0, sizeof(*pt));
+    pt->prev_lcore = lcore_id;
+    return 0;
+}
+
 /*
  * if timer is pending or stopped (or running on the same core than
  * us), mark timer as configuring, and on success return the previous

--- a/dpdk/lib/timer/rte_timer.h
+++ b/dpdk/lib/timer/rte_timer.h
@@ -191,6 +191,15 @@ void rte_timer_subsystem_finalize(void);
 void rte_timer_init(struct rte_timer *tim);
 
 /**
+ * Initialize the timer metadata.
+ * For f-stack internal use only.
+ * @return
+ *   - 0: Success
+ *   - -EINVAL: invalid timer data instance identifier
+ */
+int rte_timer_meta_init(void);
+
+/**
  * Reset and start the timer associated with the timer handle.
  *
  * The rte_timer_reset() function resets and starts the timer

--- a/lib/ff_dpdk_if.c
+++ b/lib/ff_dpdk_if.c
@@ -884,6 +884,7 @@ static int
 init_clock(void)
 {
     rte_timer_subsystem_init();
+    rte_timer_meta_init();
     uint64_t hz = rte_get_timer_hz();
     uint64_t intrs = US_PER_S / ff_global_cfg.freebsd.hz;
     uint64_t tsc = (hz + US_PER_S - 1) / US_PER_S * intrs;
@@ -894,6 +895,12 @@ init_clock(void)
 
     ff_update_current_ts();
 
+    return 0;
+}
+
+static int
+stop_clock(void) {
+    rte_timer_stop_sync(&freebsd_clock);
     return 0;
 }
 
@@ -2436,6 +2443,7 @@ ff_dpdk_run(loop_func_t loop, void *arg) {
     lr->arg = arg;
     rte_eal_mp_remote_launch(main_loop, lr, CALL_MAIN);
     rte_eal_mp_wait_lcore();
+    stop_clock();
     rte_free(lr);
 
     /* FIXME: Cleanup ff_config, freebsd etc. */


### PR DESCRIPTION
### Issue description

An infinite loop can occur in the DPDK timer subsystem under the following conditions:
1. A primary process and one or more secondary processes are running.
2. A secondary process is terminated and then restarted.
3. Upon restart, the secondary process enters an infinite loop.

### Root cause
The head of the DPDK timer's linked list is located in shared memory, which is managed and owned by the primary process.

When a secondary process restarts, it re-executes its initialization routines, including the one for `freebsd_clock`. This routine attempts to add a timer to the linked list. However, since the list already exists and was never cleaned up from the secondary process's perspective, this operation incorrectly links the timer back to itself, creating a cycle in the list. Consequently, any code that subsequently traverses this corrupted list enters an infinite loop.

### Solution
1. Ensure the `freebsd_clock` timer is stopped and removed during graceful shutdown.
2. Re-initialize the process-local timer state on startup to guarantee a clean start.