### PR TITLE
adapter/syscall: fix ioctl conflicting types compile error on older glibc

### DIFF
--- a/adapter/syscall/ff_declare_syscalls.h
+++ b/adapter/syscall/ff_declare_syscalls.h
@@ -22,7 +22,6 @@ FF_SYSCALL_DECL(ssize_t, recvfrom, (int, void *, size_t, int,
 FF_SYSCALL_DECL(ssize_t, sendmsg, (int, const struct msghdr *, int flags));
 FF_SYSCALL_DECL(ssize_t, recvmsg, (int, struct msghdr *, int flags));
 FF_SYSCALL_DECL(int, close, (int));
-FF_SYSCALL_DECL(int, ioctl, (int, unsigned long, unsigned long));
 FF_SYSCALL_DECL(int, fcntl, (int, int, unsigned long));
 FF_SYSCALL_DECL(int, epoll_create, (int));
 FF_SYSCALL_DECL(int, epoll_ctl, (int, int, int, struct epoll_event *));

--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <dlfcn.h>
 #include <unistd.h>
+#include <stdarg.h>
 #include <sys/epoll.h>
 #include <sys/resource.h>
 #include <errno.h>
@@ -1880,6 +1881,25 @@ ff_hook_ioctl(int fd, unsigned long req, unsigned long data)
     //share_mem_free(sh_data);
 
     RETURN_NOFREE();
+}
+
+/*
+ * Public ioctl() entry point with variadic signature matching glibc's
+ * declaration: int ioctl(int fd, unsigned long request, ...)
+ * This avoids the 'conflicting types' compile error when strong_alias is
+ * used against the fixed-arg ff_hook_ioctl prototype (issue #942).
+ */
+int
+ioctl(int fd, unsigned long req, ...)
+{
+    va_list ap;
+    unsigned long data;
+
+    va_start(ap, req);
+    data = va_arg(ap, unsigned long);
+    va_end(ap);
+
+    return ff_hook_ioctl(fd, req, data);
 }
 
 int

--- a/adapter/syscall/ff_linux_syscall.c
+++ b/adapter/syscall/ff_linux_syscall.c
@@ -22,6 +22,8 @@
 struct ff_linux_syscall {
     #define FF_SYSCALL_DECL(ret, fn, args)  ret (*pf_##fn) args;
     #include "ff_declare_syscalls.h"
+    /* ioctl removed from ff_declare_syscalls.h (issue #942 fix), add manually */
+    int (*pf_ioctl)(int, unsigned long, unsigned long);
 };
 
 static int linux_syscall_inited;
@@ -44,6 +46,8 @@ linux_syscall_load_symbol()
     #define FF_SYSCALL_DECL(ret, fn, args)  \
     syscalls.pf_##fn = (typeof(syscalls.pf_##fn))dlsym(linux_lib_handle, #fn);
     #include <ff_declare_syscalls.h>
+    /* ioctl removed from ff_declare_syscalls.h (issue #942 fix), load manually */
+    syscalls.pf_ioctl = (typeof(syscalls.pf_ioctl))dlsym(linux_lib_handle, "ioctl");
 
     return 0;
 }

--- a/adapter/syscall/ff_linux_syscall.h
+++ b/adapter/syscall/ff_linux_syscall.h
@@ -10,4 +10,8 @@
 #define FF_SYSCALL_DECL(ret, fn, args) ret ff_linux_##fn args
 #include "ff_declare_syscalls.h"
 
+/* ioctl is removed from ff_declare_syscalls.h (variadic conflict fix, issue #942),
+ * declare ff_linux_ioctl explicitly here. */
+int ff_linux_ioctl(int fd, unsigned long req, unsigned long data);
+
 #endif


### PR DESCRIPTION
## Problem

On systems where `sys/ioctl.h` is pulled in transitively before the `strong_alias` macro expansion (e.g. Amazon Linux 2, glibc 2.26, kernel 5.15), the LD_PRELOAD adapter fails to compile with:

```
./ff_declare_syscalls.h:25:22: error: conflicting types for 'ioctl'; have 'int(int, long unsigned int, long unsigned int)'
   25 | FF_SYSCALL_DECL(int, ioctl, (int, unsigned long, unsigned long));
/usr/include/sys/ioctl.h:42:12: note: previous declaration of 'ioctl' with type 'int(int, long unsigned int, ...)'
   42 | extern int ioctl (int __fd, unsigned long int __request, ...) __THROW;
make: *** [Makefile:129: ff_hook_syscall.o] Error 1
```

## Root Cause

`ioctl(2)` is declared as variadic in glibc:
```c
extern int ioctl(int __fd, unsigned long int __request, ...) __THROW;
```

But `ff_declare_syscalls.h` registered it with a fixed-arg prototype:
```c
FF_SYSCALL_DECL(int, ioctl, (int, unsigned long, unsigned long));
```

When `strong_alias()` expands, `__typeof(ff_hook_ioctl)` yields a fixed-arg type that conflicts with the already-declared variadic `ioctl` from `sys/ioctl.h`. Whether the error triggers depends on the glibc version's header include chain — on newer glibc (2.38+) `epoll.h` does not pull in `ioctl.h`, so the conflict never surfaces; on older glibc it does.

## Fix

- Remove `ioctl` from `ff_declare_syscalls.h` (it cannot be handled by the generic `FF_SYSCALL_DECL` / `strong_alias` mechanism due to its variadic signature).
- Add an explicit variadic public wrapper `ioctl()` in `ff_hook_syscall.c` that extracts the third argument via `va_arg` and forwards to `ff_hook_ioctl()`. This matches glibc's declaration exactly.
- Update all files that previously relied on `ff_declare_syscalls.h` to auto-generate `ioctl`-related symbols:
  - `ff_linux_syscall.h`: explicit declaration of `ff_linux_ioctl()`
  - `ff_linux_syscall.c`: manual `pf_ioctl` struct member and `dlsym()` load

## Testing

Compiled and verified on TencentOS (kernel 5.4, GCC 12.3.1, glibc 2.38). The error can be reproduced on any GCC version by manually including `sys/ioctl.h` before the macro expansion.

Fixes #942