### PR TITLE
tools/compat: add root privilege check in ff_ipc_init()

### DIFF
--- a/tools/compat/ff_ipc.c
+++ b/tools/compat/ff_ipc.c
@@ -58,6 +58,10 @@ ff_ipc_init(void)
         return 0;
     }
 
+    if (getuid() != 0) {
+        rte_exit(EXIT_FAILURE, "Error: F-Stack tools must be run as root.\n");
+    }
+
     char *dpdk_argv[] = {
         "ff-ipc", "-c1", "-n4",
         "--proc-type=secondary",


### PR DESCRIPTION
## Summary

F-Stack tools (`ifconfig`, `netstat`, `ipfw`, `arp`, etc.) are DPDK secondary processes and must be run as root. When executed as a non-root user, DPDK uses a per-user runtime directory (`/run/user/<uid>/dpdk/`) instead of the system-wide `/var/run/dpdk/`, causing a cryptic and misleading error:

```
EAL: Cannot open '/run/user/1000/dpdk/rte/config' for rte_mem_config
EAL: FATAL: Cannot init config
EAL: Error - exiting with code: 1
  Cause: Error with EAL initialization
```

This change adds an explicit root privilege check at the start of `ff_ipc_init()`, printing a clear and actionable error message before DPDK initialization is attempted.

## Change

Add to `tools/compat/ff_ipc.c`, in `ff_ipc_init()`:

```c
if (getuid() != 0) {
    rte_exit(EXIT_FAILURE, "Error: F-Stack tools must be run as root.\n");
}
```

## Before / After

**Before (as non-root):**
```
EAL: Cannot open '/run/user/1000/dpdk/rte/config' for rte_mem_config
EAL: FATAL: Cannot init config
EAL: Error - exiting with code: 1
  Cause: Error with EAL initialization
```

**After (as non-root):**
```
PANIC in ff_ipc_init():
Error: F-Stack tools must be run as root.
```

Fixes #829.