### PR TITLE
dpdk/eal: fix secondary process resetting NIC via eal_bus_cleanup()

### DIFF
--- a/dpdk/lib/eal/linux/eal.c
+++ b/dpdk/lib/eal/linux/eal.c
@@ -1370,7 +1370,18 @@ rte_eal_cleanup(void)
 	vfio_mp_sync_cleanup();
 #endif
 	rte_mp_channel_cleanup();
-	eal_bus_cleanup();
+	/* Secondary processes should not call eal_bus_cleanup() because it
+	 * invokes drv->remove() on all PCI devices, which for virtio PMD ends
+	 * up calling virtio_reset() and writing VIRTIO_CONFIG_STATUS_RESET to
+	 * the hardware.  This resets the NIC owned by the primary process,
+	 * causing it to stop accepting new connections.
+	 *
+	 * Upstream fix: commit 4bc53f8f0d64 ("eal: fix MP socket cleanup"),
+	 * DPDK >= 25.07.  Backport for F-Stack bundled DPDK 23.11.5.
+	 * See also: https://github.com/F-Stack/f-stack/issues/860
+	 */
+	if (rte_eal_process_type() == RTE_PROC_PRIMARY)
+		eal_bus_cleanup();
 	rte_eal_alarm_cleanup();
 	rte_trace_save();
 	eal_trace_fini();


### PR DESCRIPTION
## Problem

When a secondary DPDK process exits (e.g. `ff_ifconfig`, `ff_sysctl`), the primary process (F-Stack/nginx) **stops accepting new connections**. The NIC becomes non-functional until the primary process is restarted.

Reproduction:
```
# Start F-Stack primary process (nginx)
./nginx ...

# Run any f-stack tool (even just --help triggers the bug)
./ff_ifconfig --help   # primary stops receiving packets after this returns
```

## Root Cause

DPDK commit `1cab1a40ea9b` ("bus: cleanup devices on shutdown", introduced in DPDK 22.11) added `eal_bus_cleanup()` to `rte_eal_cleanup()` without distinguishing between primary and secondary processes.

When `rte_eal_cleanup()` is called in the secondary process, it executes:

```
rte_mp_channel_cleanup()    <- closes IPC socket
eal_bus_cleanup()           <- calls drv->remove() on ALL PCI devices
  -> pci_cleanup()
  -> drv->remove(dev)       <- eth_virtio_pci_remove()
  -> virtio_dev_close()
  -> virtio_reset(hw)       <- writes 0x00 to VIRTIO_CONFIG_STATUS_RESET !
```

`virtio_reset()` performs a full hardware reset of the NIC. The primary process still holds the device but its hardware state has been destroyed.

## Fix

Guard `eal_bus_cleanup()` with a primary-process check so secondary processes skip the bus cleanup:

```c
if (rte_eal_process_type() == RTE_PROC_PRIMARY)
    eal_bus_cleanup();
```

This is consistent with the fix in upstream DPDK commit `4bc53f8f0d64` ("eal: fix MP socket cleanup"), which was merged for DPDK 25.07. The upstream fix also reorders `eal_bus_cleanup()` before `rte_mp_channel_cleanup()` to handle IPC-dependent cleanup in drivers; this backport takes the simpler approach of skipping bus cleanup in secondary processes entirely.

## Affected Versions

All DPDK LTS releases that include commit `1cab1a40ea9b` are affected:
- DPDK 22.11.x (all point releases)
- DPDK 23.11.x (including F-Stack bundled 23.11.5)
- DPDK 24.11.x (up to at least 24.11.4)

The fix is available in DPDK 25.07+ only.

## References

- Issue: https://github.com/F-Stack/f-stack/issues/860
- Upstream fix: DPDK commit `4bc53f8f0d64` ("eal: fix MP socket cleanup", 2025-07-19)
- Bug-introducing commit: `1cab1a40ea9b` ("bus: cleanup devices on shutdown", 2022-10-04)
