### PR TITLE
fix(bbr): correct argument order in bbr_get_raw_target_cwnd calls

### DIFF
--- a/freebsd/netinet/tcp_stacks/bbr.c
+++ b/freebsd/netinet/tcp_stacks/bbr.c
@@ -3466,7 +3466,7 @@ bbr_get_target_cwnd(struct tcp_bbr *bbr, uint64_t bw, uint32_t gain)
 
 	mss = min((bbr->rc_tp->t_maxseg - bbr->rc_last_options), bbr->r_ctl.rc_pace_max_segs);
 	/* Get the base cwnd with gain rounded to a mss */
-	cwnd = roundup(bbr_get_raw_target_cwnd(bbr, bw, gain), mss);
+	cwnd = roundup(bbr_get_raw_target_cwnd(bbr, gain, bw), mss);
 	/*
 	 * Add in N (2 default since we do not have a
 	 * fq layer to trap packets in) quanta's per the I-D
@@ -10718,8 +10718,8 @@ bbr_get_a_state_target(struct tcp_bbr *bbr, uint32_t gain)
 		mss = min((bbr->rc_tp->t_maxseg - bbr->rc_last_options),
 			  bbr->r_ctl.rc_pace_max_segs);
 		/* Get the base cwnd with gain rounded to a mss */
-		tar = roundup(bbr_get_raw_target_cwnd(bbr, bbr_get_bw(bbr),
-						      gain), mss);
+		tar = roundup(bbr_get_raw_target_cwnd(bbr, gain,
+						      bbr_get_bw(bbr)), mss);
 		/* Make sure it is within our min */
 		if (tar < get_min_cwnd(bbr))
 			return (get_min_cwnd(bbr));


### PR DESCRIPTION
## Problem

The function `bbr_get_raw_target_cwnd` has the following signature:

```c
static uint32_t
bbr_get_raw_target_cwnd(struct tcp_bbr *bbr, uint32_t gain, uint64_t bw)
```

But two call sites had `bw` and `gain` swapped:

**In `bbr_get_target_cwnd` (line 3469):**
```c
// Before (wrong)
cwnd = roundup(bbr_get_raw_target_cwnd(bbr, bw, gain), mss);
// After (correct)
cwnd = roundup(bbr_get_raw_target_cwnd(bbr, gain, bw), mss);
```

**In `bbr_get_a_state_target` (line 10721):**
```c
// Before (wrong)
tar = roundup(bbr_get_raw_target_cwnd(bbr, bbr_get_bw(bbr), gain), mss);
// After (correct)
tar = roundup(bbr_get_raw_target_cwnd(bbr, gain, bbr_get_bw(bbr)), mss);
```

## Impact

Due to the swapped arguments:
- `bw` (uint64_t, actual bandwidth in bytes/sec) was truncated to uint32_t and used as the gain multiplier
- `gain` (uint32_t, a small multiplier such as BBR_UNIT=1024) was used as the bandwidth value

This causes the BDP (Bandwidth-Delay Product) to be computed with a wildly incorrect bandwidth value, resulting in a severely underestimated congestion window when using the BBR algorithm, which prevents BBR from achieving high throughput (as reported in #1032).

Note: this is an upstream FreeBSD bug present in all versions (releng/13.0 through releng/15.0 and main).

Fixes #1032