### PR TITLE
fix(syscall): add addrlen bounds check in ff_hook_bind

### DIFF
--- a/adapter/syscall/ff_hook_syscall.c
+++ b/adapter/syscall/ff_hook_syscall.c
@@ -437,6 +437,11 @@ ff_hook_bind(int fd, const struct sockaddr *addr,
         return -1;
     }
 
+    if (addrlen > sizeof(struct sockaddr_storage)) {
+        errno = EINVAL;
+        return -1;
+    }
+
     CHECK_FD_OWNERSHIP(bind, (fd, addr, addrlen));
 
     DEFINE_REQ_ARGS(bind);


### PR DESCRIPTION
Cherry-picks the bind() bounds check from #1067 and omits the accompanying test file.

### Change
Reject `ff_hook_bind` calls with `addrlen > sizeof(struct sockaddr_storage)` to prevent out-of-bounds reads when copying the address into shared memory via `rte_memcpy`.

```c
if (addrlen > sizeof(struct sockaddr_storage)) {
    errno = EINVAL;
    return -1;
}
```

### Why this PR (instead of merging #1067 directly)
- The bind bounds check itself is a reasonable defensive hardening, so it is kept.
- The test file `tests/test_invariant_ff_hook_syscall.c` introduced in #1067 was intentionally **not** included, because:
  - It does not actually call `ff_hook_bind`; it only re-implements an `if (addrlen > 128)` check and asserts on its own logic, so it does not cover the modified code path.
  - The threshold `128` is hard-coded and inconsistent with the actual fix, which uses `sizeof(struct sockaddr_storage)`.
  - It introduces a new dependency on the `check` framework that is not part of the existing build.
  - The file is missing a trailing newline.

### Risk
Low. `addrlen` originates from the calling process's own `bind()`, not from remote input, so this is defensive hardening rather than a remotely-exploitable fix.

### Test
- `make ff_hook_syscall.o` and full `make` in `adapter/syscall/` succeed under `-Wall -Werror -O2` with no warnings or errors. The only link-time miss is `-lfstack`, which is produced by the upper `lib/` target and unrelated to this change.

Closes part of #1067 (the bind hardening).