### PR TITLE
Import `errno.h` in `adapter/syscall/ff_socket_ops.c`

### DIFF
--- a/adapter/syscall/ff_socket_ops.c
+++ b/adapter/syscall/ff_socket_ops.c
@@ -1,3 +1,5 @@
+#include <errno.h>
+
 #include <rte_memcpy.h>
 #include <rte_spinlock.h>
 #ifdef FF_USE_RING_IPC


### PR DESCRIPTION
## Overview

Building `libff_syscall.so` fails on certain instances (below spec) because `adapter/syscall/ff_socket_ops.c` uses `errno` / `EINVAL` without including `errno.h`.

## Environment

| Component | Version |
|-----------|---------|
| OS        | RHEL 10.1 |
| F-Stack   | 1.25 |
| gcc       | 14.3.1 |
| dpdk      | 25.11.2 |

## Build error

```
$ make clean all
Makefile:129: warning: overriding recipe for target 'ff_so_zone.o'
Makefile:126: warning: ignoring old recipe for target 'ff_so_zone.o'
rm -f *.o fstack libff_syscall.so example
cc -c -g -O2 -DNDEBUG -fPIC -Wall -Werror -I/usr/local/include -include rte_config.h -march=native -mrtm -I. -I/data/f-stack-1.25/lib   fstack.c
cc -c -g -O2 -DNDEBUG -fPIC -Wall -Werror -I/usr/local/include -include rte_config.h -march=native -mrtm -I. -I/data/f-stack-1.25/lib   ff_so_zone.c
cc -c -g -O2 -DNDEBUG -fPIC -Wall -Werror -I/usr/local/include -include rte_config.h -march=native -mrtm -I. -I/data/f-stack-1.25/lib   ff_socket_ops.c
ff_socket_ops.c: In function ‘ff_so_handler’:
ff_socket_ops.c:497:5: error: ‘errno’ undeclared (first use in this function)
  497 |     errno = EINVAL;
      |     ^~~~~
ff_socket_ops.c:14:1: note: ‘errno’ is defined in header ‘<errno.h>’; this is probably fixable by adding ‘#include <errno.h>’
   13 | #include <ff_declare_syscalls.h>
  +++ |+#include <errno.h>
   14 | static int ff_sys_kqueue(struct ff_kqueue_args *args);
ff_socket_ops.c:497:5: note: each undeclared identifier is reported only once for each function it appears in
  497 |     errno = EINVAL;
      |     ^~~~~
ff_socket_ops.c:497:13: error: ‘EINVAL’ undeclared (first use in this function); did you mean ‘ff_EINVAL’?
  497 |     errno = EINVAL;
      |             ^~~~~~
      |             ff_EINVAL
ff_socket_ops.c: In function ‘ff_handle_socket_ops’:
ff_socket_ops.c:521:5: error: ‘errno’ undeclared (first use in this function)
  521 |     errno = 0;
      |     ^~~~~
ff_socket_ops.c:521:5: note: ‘errno’ is defined in header ‘<errno.h>’; this is probably fixable by adding ‘#include <errno.h>’
make: *** [Makefile:126: ff_socket_ops.o] Error 1
```

With this change, `make clean all` in `adapter/syscall/` completes successfully in the environment above.

## Additional note on ff_so_zone.c

`ff_so_zone.c` also uses `errno` (sem_init failure path) without a direct `#include <errno.h>`. It currently compiles because dpdk 25.11.2 includes it transitively with `rte_eal.h`/`rte_memzone.h`. It is left out of this PR to keep the change minimal to the observed build break, but the same one line fix would apply as well if dpdk changes.